### PR TITLE
Slight refactoring, fix typos

### DIFF
--- a/Source/AssetGenerator.csproj
+++ b/Source/AssetGenerator.csproj
@@ -74,11 +74,7 @@
     <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Resources\Figures\Indices.png">

--- a/Source/Data.cs
+++ b/Source/Data.cs
@@ -41,7 +41,7 @@ namespace AssetGenerator
 
         public static void Write(this BinaryWriter writer, IEnumerable<Quaternion> values)
         {
-            values.ForEach(value => writer.Write(value));
+            values.ForEach(writer.Write);
         }
 
         public static void Write(this BinaryWriter writer, Vector4 value)
@@ -54,7 +54,7 @@ namespace AssetGenerator
 
         public static void Write(this BinaryWriter writer, IEnumerable<Vector4> values)
         {
-            values.ForEach(value => writer.Write(value));
+            values.ForEach(writer.Write);
         }
 
         public static void Write(this BinaryWriter writer, Vector3 value)
@@ -66,7 +66,7 @@ namespace AssetGenerator
 
         public static void Write(this BinaryWriter writer, IEnumerable<Vector3> values)
         {
-            values.ForEach(value => writer.Write(value));
+            values.ForEach(writer.Write);
         }
 
         public static void Write(this BinaryWriter writer, Vector2 value)
@@ -97,17 +97,17 @@ namespace AssetGenerator
 
         public static void Write(this BinaryWriter writer, IEnumerable<Vector2> values)
         {
-            values.ForEach(value => writer.Write(value));
+            values.ForEach(writer.Write);
         }
 
         public static void Write(this BinaryWriter writer, IEnumerable<Single> values)
         {
-            values.ForEach(value => writer.Write(value));
+            values.ForEach(writer.Write);
         }
 
         public static void Write(this BinaryWriter writer, IEnumerable<Matrix4x4> values)
         {
-            values.ForEach(value => writer.Write(value));
+            values.ForEach(writer.Write);
         }
         
     }

--- a/Source/FileHelper.cs
+++ b/Source/FileHelper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace AssetGenerator
 {
@@ -39,7 +38,7 @@ namespace AssetGenerator
         }
 
         /// <summary>
-        ///  Builds a list of the names of each file in the targeted folder, to be later useded in creating image URIs.
+        ///  Builds a list of the names of each file in the targeted folder, to be later used in creating image URIs.
         ///  Only looks at files in folders in the directory, and only one level deep.
         /// </summary>
         public static List<string> FindImageFiles(string imageFolder)
@@ -65,7 +64,7 @@ namespace AssetGenerator
             {
                 foreach (var image in usedImages)
                 {
-                    string name = FormatForFileSystem(image.Uri.ToString());
+                    string name = FormatForFileSystem(image.Uri);
 
                     var source = Path.Combine(executingAssemblyFolder, "Resources", name);
                     var destination = Path.Combine(outputFolder, name);
@@ -74,7 +73,7 @@ namespace AssetGenerator
                 }
             }
 
-            if (useThumbnails == true)
+            if (useThumbnails)
             {
                 CopyThumbnailImageFiles(executingAssemblyFolder, outputFolder, usedImages);
             }
@@ -94,7 +93,7 @@ namespace AssetGenerator
                 usedThumbnailImages.Add(
                     new Runtime.Image()
                     {
-                        Uri = FormatForUri(Path.Combine("Figures", "Thumbnails", Path.GetFileName(image.Uri.ToString())))
+                        Uri = FormatForUri(Path.Combine("Figures", "Thumbnails", Path.GetFileName(image.Uri)))
                     });
             }
 
@@ -103,7 +102,7 @@ namespace AssetGenerator
         }
 
         /// <summary>
-        /// Converts the seperators in a relative local path into those needed for a Uri.
+        /// Converts the separators in a relative local path into those needed for a Uri.
         /// For use in building a Uri for an image.
         /// </summary>
         static string FormatForUri(string path)
@@ -112,7 +111,7 @@ namespace AssetGenerator
         }
 
         /// <summary>
-        /// Converts the seperators in a uri string into a relative local path.
+        /// Converts the separators in a uri string into a relative local path.
         /// For use in recreating the local path from a Uri.
         /// </summary>
         static string FormatForFileSystem(string path)

--- a/Source/Manifest.cs
+++ b/Source/Manifest.cs
@@ -38,9 +38,9 @@ namespace AssetGenerator
         {
             public float[] Translation = new float[3];
 
-            public Camera(Vector3 cameratranslation)
+            public Camera(Vector3 cameraTranslation)
             {
-                cameratranslation.CopyTo(Translation);
+                cameraTranslation.CopyTo(Translation);
             }
         }
 

--- a/Source/ModelGroup_MultiNode.cs
+++ b/Source/ModelGroup_MultiNode.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 
 namespace AssetGenerator

--- a/Source/ModelGroup_SkinC.cs
+++ b/Source/ModelGroup_SkinC.cs
@@ -158,7 +158,7 @@ namespace AssetGenerator
                 };
                 nodePlane.Skin.SkinJoints = skinJointsList;
 
-                // Assign joint weights to pairs of vertexs
+                // Assign joint weights to pairs of vertices
                 var weightsList = new List<List<Runtime.JointWeight>>();
                 int jointIndex = 0;
                 for (int vertexIndex = 0; vertexIndex < 10; vertexIndex++)

--- a/Source/ModelGroup_SkinD.cs
+++ b/Source/ModelGroup_SkinD.cs
@@ -158,7 +158,7 @@ namespace AssetGenerator
                 };
                 nodePlane.Skin.SkinJoints = skinJointsList;
 
-                // Assign joint weights to pairs of vertexs, except the last four which all share a joint
+                // Assign joint weights to pairs of vertices, except the last four which all share a joint
                 var weightsList = new List<List<Runtime.JointWeight>>();
                 int jointIndex = 0;
                 for (int vertexIndex = 0; vertexIndex < 6; vertexIndex++)

--- a/Source/ModelGroups/Animation_Node.cs
+++ b/Source/ModelGroups/Animation_Node.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
-using System.Text;
 
 namespace AssetGenerator
 {

--- a/Source/ModelGroups/Animation_NodeMisc.cs
+++ b/Source/ModelGroups/Animation_NodeMisc.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Text;
 
 namespace AssetGenerator
 {

--- a/Source/ModelGroups/Animation_Skin.cs
+++ b/Source/ModelGroups/Animation_Skin.cs
@@ -31,7 +31,7 @@ namespace AssetGenerator
                 setProperties(properties, animations, nodes);
 
                 // If no animations are used, null out that property.
-                if (animations.Count() == 0)
+                if (!animations.Any())
                 {
                     animations = null;
                 }
@@ -169,7 +169,7 @@ namespace AssetGenerator
                     }
 
                     properties.Add(new Property(PropertyName.Description, "`skinA`. The skin joints are not referenced by the scene nodes."));
-                }, (glTFLoader.Schema.Gltf gltf) => {gltf.Scenes.First().Nodes = new int[]{0,};}),
+                }, (gltf) => {gltf.Scenes.First().Nodes = new []{0,};}),
                 CreateModel((properties, animations, nodes) => {
                     foreach (var node in Nodes.CreatePlaneWithSkinA())
                     {
@@ -250,7 +250,7 @@ namespace AssetGenerator
                     for (int skinJointIndex = 1; skinJointIndex < skinJointList.Count(); skinJointIndex++)
                     {
                         var translationInverseBindMatrix = skinJointList.ElementAt(skinJointIndex).InverseBindMatrix;
-                        Matrix4x4.Invert(Matrix4x4.CreateRotationX(rotationRadian * (skinJointIndex + 1)) , out invertedRotation);
+                        Matrix4x4.Invert(Matrix4x4.CreateRotationX(rotationRadian * (skinJointIndex + 1)), out invertedRotation);
                         skinJointList.ElementAt(skinJointIndex).InverseBindMatrix = Matrix4x4.Multiply(translationInverseBindMatrix, invertedRotation);
                     }
 

--- a/Source/ModelGroups/Compatibility.cs
+++ b/Source/ModelGroups/Compatibility.cs
@@ -1,11 +1,9 @@
-﻿using glTFLoader.Shared;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Reflection;
 
 namespace AssetGenerator
 {
@@ -133,7 +131,7 @@ namespace AssetGenerator
                 {
                     new ExperimentalLight
                     {
-                        Color = new float[] { 0.3f, 0.4f, 0.5f }
+                        Color = new[] { 0.3f, 0.4f, 0.5f }
                     }
                 };
             }
@@ -148,7 +146,7 @@ namespace AssetGenerator
             void SetPostRuntimeWithFallback(glTFLoader.Schema.Gltf gltf)
             {
                 // Add an simulated feature with a fallback option
-                gltf.Materials = new[]
+                gltf.Materials = new glTFLoader.Schema.Material[]
                 {
                     new ExperimentalMaterial
                     {

--- a/Source/ModelGroups/Material.cs
+++ b/Source/ModelGroups/Material.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 
 namespace AssetGenerator

--- a/Source/ModelGroups/Mesh_PrimitiveMode.cs
+++ b/Source/ModelGroups/Mesh_PrimitiveMode.cs
@@ -192,7 +192,7 @@ namespace AssetGenerator
 
             void SetIndicesLines(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)
             {
-                meshPrimitive.Positions = GetSinglePlaneNonReversablePositions();
+                meshPrimitive.Positions = GetSinglePlaneNonReversiblePositions();
                 meshPrimitive.Indices = new List<int>
                 {
                     0, 3, 3, 2, 2, 1, 1, 0,
@@ -202,7 +202,7 @@ namespace AssetGenerator
 
             void SetIndicesLineLoop(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)
             {
-                meshPrimitive.Positions = GetSinglePlaneNonReversablePositions();
+                meshPrimitive.Positions = GetSinglePlaneNonReversiblePositions();
                 meshPrimitive.Indices = new List<int>
                 {
                     0, 3, 2, 1,
@@ -222,7 +222,7 @@ namespace AssetGenerator
 
             void SetIndicesLineStrip(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)
             {
-                meshPrimitive.Positions = GetSinglePlaneNonReversablePositions();
+                meshPrimitive.Positions = GetSinglePlaneNonReversiblePositions();
                 meshPrimitive.Indices = new List<int>
                 {
                     0, 3, 2, 1, 0,
@@ -357,7 +357,7 @@ namespace AssetGenerator
         /// <summary>
         ///  Used to generate positions for points and lines modes, so it is easy to see if the model is reversed or not.
         /// </summary>
-        private static List<Vector3> GetSinglePlaneNonReversablePositions()
+        private static List<Vector3> GetSinglePlaneNonReversiblePositions()
         {
             return new List<Vector3>()
             {

--- a/Source/ModelGroups/Mesh_PrimitivesUV.cs
+++ b/Source/ModelGroups/Mesh_PrimitivesUV.cs
@@ -1,5 +1,4 @@
-﻿using AssetGenerator.Runtime.ExtensionMethods;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;

--- a/Source/ModelGroups/Node_NegativeScale.cs
+++ b/Source/ModelGroups/Node_NegativeScale.cs
@@ -50,7 +50,7 @@ namespace AssetGenerator
                 // Apply the properties that are specific to this gltf.
                 setProperties(properties, nodes[0], nodes[1]);
 
-                // Applies a translation to avoid clippine the other node. 
+                // Applies a translation to avoid clipping the other node. 
                 // Models with a matrix applied have the translation applied in that matrix.
                 if (properties.Find(e => e.Name == PropertyName.Matrix) == null)
                 {

--- a/Source/Property.cs
+++ b/Source/Property.cs
@@ -67,7 +67,7 @@ namespace AssetGenerator
                 if (elementType == null) // Catch for types in System.Numerics
                 {
                     elementType = Type.GetType(
-                        type.AssemblyQualifiedName.ToString().Replace("[]", string.Empty));
+                        type.AssemblyQualifiedName.Replace("[]", string.Empty));
                 }
                 var array = obj as Array;
                 Array copied = Array.CreateInstance(elementType, array.Length);

--- a/Source/ReadmeBuilder.cs
+++ b/Source/ReadmeBuilder.cs
@@ -68,14 +68,12 @@ namespace AssetGenerator
                     ":---:", // Hyphens for row after header
                     ":---:",
                     });
-                for (int i = 0; i < test.CommonProperties.Count; i++)
+                foreach (var property in test.CommonProperties)
                 {
-                    string attributeName;
-                    attributeName = test.CommonProperties[i].ReadmeColumnName;
                     readmePrereqs.Add(new List<string>
                     {
-                        attributeName,
-                        test.CommonProperties[i].ReadmeValue
+                        property.ReadmeColumnName,
+                        property.ReadmeValue
                     });
                 }
             }
@@ -102,8 +100,7 @@ namespace AssetGenerator
             // Generates the list of column names for use when setting up the table, and generates that part of the table as well.
             foreach (var property in test.Properties)
             {
-                string attributeName;
-                attributeName = property.ReadmeColumnName;
+                var attributeName = property.ReadmeColumnName;
 
                 if (!columnNames.Contains(property.Name))
                 {
@@ -139,7 +136,7 @@ namespace AssetGenerator
 
             // Checks the list of properties used in the model against the list of column names. 
             // If there is no property that matches a column name, that cell is left blank. Otherwise the property value is added to that cell.
-            // There is no handeling for multiple properties with the same name on the same model.
+            // There is no handling for multiple properties with the same name on the same model.
             int logIndex = readme.Count - 1;
             foreach (var possibleAttribute in columnNames)
             {

--- a/Source/ReadmeStringHelper.cs
+++ b/Source/ReadmeStringHelper.cs
@@ -47,7 +47,7 @@ namespace AssetGenerator
                 else if (valueType.Equals(typeof(Runtime.Image)))
                 {
                     // 18 is normal cell height. Use height=\"72\" width=\"72\" to clamp the size, but currently removed
-                    // due to streching when the table is too wide. Using thumbnails of the intended size for now.
+                    // due to stretching when the table is too wide. Using thumbnails of the intended size for now.
                     Regex changePath = new Regex(@"(.*)(?=\/)");
                     string thumbnailPath = changePath.Replace(value.Uri, "Figures/Thumbnails", 1);
                     output = $"[<img src=\"{thumbnailPath}\" align=\"middle\">]({value.Uri})";
@@ -162,7 +162,7 @@ namespace AssetGenerator
 
             for (int i = 0; i < paramSet.Count; i++)
             {
-                name[i] = paramSet[i].ReadmeValue.ToString();
+                name[i] = paramSet[i].ReadmeValue;
             }
             if (name == null)
             {

--- a/Source/Runtime/ExtensionMethods/IEnumerableExtensionMethods.cs
+++ b/Source/Runtime/ExtensionMethods/IEnumerableExtensionMethods.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 
 namespace AssetGenerator.Runtime.ExtensionMethods
 {

--- a/Source/Runtime/ExtensionMethods/ImageExtensionMethods.cs
+++ b/Source/Runtime/ExtensionMethods/ImageExtensionMethods.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AssetGenerator.Runtime.ExtensionMethods
+﻿namespace AssetGenerator.Runtime.ExtensionMethods
 {
     internal static class ImageExtensionMethods
     {

--- a/Source/Runtime/ExtensionMethods/NumericExtensionMethods.cs
+++ b/Source/Runtime/ExtensionMethods/NumericExtensionMethods.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Numerics;
 
 namespace AssetGenerator.Runtime.ExtensionMethods
 {

--- a/Source/Runtime/ExtensionMethods/SamplerExtensionMethods.cs
+++ b/Source/Runtime/ExtensionMethods/SamplerExtensionMethods.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AssetGenerator.Runtime.ExtensionMethods
+﻿namespace AssetGenerator.Runtime.ExtensionMethods
 {
     internal static class SamplerExtensionMethods
     {

--- a/Source/Runtime/ExtensionMethods/TextureExtensionMethods.cs
+++ b/Source/Runtime/ExtensionMethods/TextureExtensionMethods.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AssetGenerator.Runtime.ExtensionMethods
+﻿namespace AssetGenerator.Runtime.ExtensionMethods
 {
     internal static class TextureExtensionMethods
     {

--- a/Source/Runtime/Extensions/FAKE_materials_quantumRendering.cs
+++ b/Source/Runtime/Extensions/FAKE_materials_quantumRendering.cs
@@ -13,13 +13,7 @@ namespace AssetGenerator.Runtime.Extensions
         /// <summary>
         /// The name of the extension
         /// </summary>
-        public override string Name
-        {
-            get
-            {
-                return nameof(FAKE_materials_quantumRendering);
-            }
-        }
+        public override string Name => nameof(FAKE_materials_quantumRendering);
 
         /// <summary>
         /// The reflected diffuse factor of the material

--- a/Source/Runtime/Extensions/KHR_materials_pbrSpecularGlossiness.cs
+++ b/Source/Runtime/Extensions/KHR_materials_pbrSpecularGlossiness.cs
@@ -7,13 +7,7 @@ namespace AssetGenerator.Runtime.Extensions
         /// <summary>
         /// The name of the extension
         /// </summary>
-        public override string Name
-        {
-            get
-            {
-                return nameof(KHR_materials_pbrSpecularGlossiness);
-            }
-        }
+        public override string Name => nameof(KHR_materials_pbrSpecularGlossiness);
 
         /// <summary>
         /// The reflected diffuse factor of the material

--- a/Source/Runtime/GLTFConverter.cs
+++ b/Source/Runtime/GLTFConverter.cs
@@ -259,7 +259,7 @@ namespace AssetGenerator.Runtime
         /// <summary>
         /// Adds a texture to the property components of the GLTFWrapper.
         /// </summary>
-        /// <returns>Returns the indicies of the texture and the texture coordinate as an array of two integers if created.  Can also return null if the index is not defined. (</returns>
+        /// <returns>Returns the indices of the texture and the texture coordinate as an array of two integers if created.  Can also return null if the index is not defined. (</returns>
         private TextureIndices AddTexture(Texture runtimeTexture)
         {
             if (this.textureToTextureIndicesCache.TryGetValue(runtimeTexture, out TextureIndices textureIndices))
@@ -356,7 +356,7 @@ namespace AssetGenerator.Runtime
             for (int i = 0; i < additionalPaddedBytes; ++i)
             {
                 geometryData.Writer.Write((byte)0);
-            };
+            }
             value += additionalPaddedBytes;
 
             return value;
@@ -516,7 +516,7 @@ namespace AssetGenerator.Runtime
                 }
                 node.Children = childrenIndices.ToArray();
             }
-            if (runtimeNode.Skin != null && runtimeNode.Skin.SkinJoints != null && runtimeNode.Skin.SkinJoints.Any())
+            if (runtimeNode.Skin?.SkinJoints?.Any() == true)
             {
                 int skinIndex;
                 if (this.skinsToIndexCache.TryGetValue(runtimeNode.Skin, out skinIndex))
@@ -713,7 +713,7 @@ namespace AssetGenerator.Runtime
                     if (baseColorIndices.TextureCoordIndex.HasValue)
                     {
                         schemaMaterial.PbrMetallicRoughness.BaseColorTexture.TexCoord = baseColorIndices.TextureCoordIndex.Value;
-                    };
+                    }
                 }
                 if (runtimeMaterial.MetallicRoughnessMaterial.MetallicRoughnessTexture != null)
                 {
@@ -749,17 +749,17 @@ namespace AssetGenerator.Runtime
             }
             if (runtimeMaterial.NormalTexture != null)
             {
-                var normalIndicies = AddTexture(runtimeMaterial.NormalTexture);
+                var normalIndices = AddTexture(runtimeMaterial.NormalTexture);
                 schemaMaterial.NormalTexture = CreateInstance<glTFLoader.Schema.MaterialNormalTextureInfo>();
 
-                if (normalIndicies.ImageIndex.HasValue)
+                if (normalIndices.ImageIndex.HasValue)
                 {
-                    schemaMaterial.NormalTexture.Index = normalIndicies.ImageIndex.Value;
+                    schemaMaterial.NormalTexture.Index = normalIndices.ImageIndex.Value;
 
                 }
-                if (normalIndicies.TextureCoordIndex.HasValue)
+                if (normalIndices.TextureCoordIndex.HasValue)
                 {
-                    schemaMaterial.NormalTexture.TexCoord = normalIndicies.TextureCoordIndex.Value;
+                    schemaMaterial.NormalTexture.TexCoord = normalIndices.TextureCoordIndex.Value;
                 }
                 if (runtimeMaterial.NormalScale.HasValue)
                 {
@@ -768,15 +768,15 @@ namespace AssetGenerator.Runtime
             }
             if (runtimeMaterial.OcclusionTexture != null)
             {
-                var occlusionIndicies = AddTexture(runtimeMaterial.OcclusionTexture);
+                var occlusionIndices = AddTexture(runtimeMaterial.OcclusionTexture);
                 schemaMaterial.OcclusionTexture = CreateInstance<glTFLoader.Schema.MaterialOcclusionTextureInfo>();
-                if (occlusionIndicies.ImageIndex.HasValue)
+                if (occlusionIndices.ImageIndex.HasValue)
                 {
-                    schemaMaterial.OcclusionTexture.Index = occlusionIndicies.ImageIndex.Value;
-                };
-                if (occlusionIndicies.TextureCoordIndex.HasValue)
+                    schemaMaterial.OcclusionTexture.Index = occlusionIndices.ImageIndex.Value;
+                }
+                if (occlusionIndices.TextureCoordIndex.HasValue)
                 {
-                    schemaMaterial.OcclusionTexture.TexCoord = occlusionIndicies.TextureCoordIndex.Value;
+                    schemaMaterial.OcclusionTexture.TexCoord = occlusionIndices.TextureCoordIndex.Value;
                 }
                 if (runtimeMaterial.OcclusionStrength.HasValue)
                 {
@@ -785,15 +785,15 @@ namespace AssetGenerator.Runtime
             }
             if (runtimeMaterial.EmissiveTexture != null)
             {
-                var emissiveIndicies = AddTexture(runtimeMaterial.EmissiveTexture);
+                var emissiveIndices = AddTexture(runtimeMaterial.EmissiveTexture);
                 schemaMaterial.EmissiveTexture = CreateInstance<glTFLoader.Schema.TextureInfo>();
-                if (emissiveIndicies.ImageIndex.HasValue)
+                if (emissiveIndices.ImageIndex.HasValue)
                 {
-                    schemaMaterial.EmissiveTexture.Index = emissiveIndicies.ImageIndex.Value;
+                    schemaMaterial.EmissiveTexture.Index = emissiveIndices.ImageIndex.Value;
                 }
-                if (emissiveIndicies.TextureCoordIndex.HasValue)
+                if (emissiveIndices.TextureCoordIndex.HasValue)
                 {
-                    schemaMaterial.EmissiveTexture.TexCoord = emissiveIndicies.TextureCoordIndex.Value;
+                    schemaMaterial.EmissiveTexture.TexCoord = emissiveIndices.TextureCoordIndex.Value;
                 }
             }
             if (runtimeMaterial.AlphaMode.HasValue)

--- a/Source/Runtime/Image.cs
+++ b/Source/Runtime/Image.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AssetGenerator.Runtime
+﻿namespace AssetGenerator.Runtime
 {
     /// <summary>
     /// Wrapper for Image class

--- a/Source/Runtime/MeshPrimitive.cs
+++ b/Source/Runtime/MeshPrimitive.cs
@@ -66,7 +66,7 @@ namespace AssetGenerator.Runtime
         public enum IndexComponentTypeEnum { UNSIGNED_INT, UNSIGNED_BYTE, UNSIGNED_SHORT };
 
         /// <summary>
-        /// Specifices which component type to use when defining the indices accessor
+        /// Specifies which component type to use when defining the indices accessor
         /// </summary>
         public IndexComponentTypeEnum IndexComponentType { get; set; }
 

--- a/Source/Runtime/Node.cs
+++ b/Source/Runtime/Node.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Numerics;
 
 namespace AssetGenerator.Runtime

--- a/Source/Runtime/Sampler.cs
+++ b/Source/Runtime/Sampler.cs
@@ -1,7 +1,7 @@
 ﻿namespace AssetGenerator.Runtime
 {
     /// <summary>
-    /// Wrapper for glTF loader's Sampler.  The sampler descibe the wrapping and scaling of textures.
+    /// Wrapper for glTF loader's Sampler.  The sampler describe the wrapping and scaling of textures.
     /// </summary>
     internal class Sampler
     {

--- a/Source/Schema/FAKE_materials_quantumRendering.cs
+++ b/Source/Schema/FAKE_materials_quantumRendering.cs
@@ -1,8 +1,6 @@
 ﻿namespace glTFLoader.Schema
 {
     using System.Linq;
-    using System.Runtime.Serialization;
-
 
     public class FAKE_materials_quantumRendering
     {
@@ -56,10 +54,7 @@
         [Newtonsoft.Json.JsonPropertyAttribute("planckFactor")]
         public float[] PlanckFactor
         {
-            get
-            {
-                return this.m_planckFactor;
-            }
+            get => this.m_planckFactor;
             set
             {
                 if ((value.Length < 4u))
@@ -95,10 +90,7 @@
         [Newtonsoft.Json.JsonPropertyAttribute("copenhagenTexture")]
         public TextureInfo CopenhagenTexture
         {
-            get
-            {
-                return this.m_copenhagenTexture;
-            }
+            get => this.m_copenhagenTexture;
             set
             {
                 this.m_copenhagenTexture = value;
@@ -112,10 +104,7 @@
         [Newtonsoft.Json.JsonPropertyAttribute("entanglementFactor")]
         public float[] EntanglementFactor
         {
-            get
-            {
-                return this.m_entanglementFactor;
-            }
+            get => this.m_entanglementFactor;
             set
             {
                 if ((value.Length < 3u))
@@ -151,10 +140,7 @@
         [Newtonsoft.Json.JsonPropertyAttribute("probabilisticFactor")]
         public float ProbabilisticFactor
         {
-            get
-            {
-                return this.m_probabilisticFactor;
-            }
+            get => this.m_probabilisticFactor;
             set
             {
                 if ((value < 0D))
@@ -175,10 +161,7 @@
         [Newtonsoft.Json.JsonPropertyAttribute("superpositionCollapseTexture")]
         public TextureInfo SuperpositionCollapseTexture
         {
-            get
-            {
-                return this.m_superpositionCollapseTexture;
-            }
+            get => this.m_superpositionCollapseTexture;
             set
             {
                 this.m_superpositionCollapseTexture = value;
@@ -191,10 +174,7 @@
         [Newtonsoft.Json.JsonPropertyAttribute("extensions")]
         public System.Collections.Generic.Dictionary<string, object> Extensions
         {
-            get
-            {
-                return this.m_extensions;
-            }
+            get => this.m_extensions;
             set
             {
                 this.m_extensions = value;
@@ -207,10 +187,7 @@
         [Newtonsoft.Json.JsonPropertyAttribute("extras")]
         public Extras Extras
         {
-            get
-            {
-                return this.m_extras;
-            }
+            get => this.m_extras;
             set
             {
                 this.m_extras = value;
@@ -219,7 +196,7 @@
 
         public bool ShouldSerializeDiffuseFactor()
         {
-            return (m_planckFactor.SequenceEqual(new float[] {
+            return (m_planckFactor.SequenceEqual(new[] {
                         1F,
                         1F,
                         1F,
@@ -234,7 +211,7 @@
 
         public bool ShouldSerializeSpecularFactor()
         {
-            return (m_entanglementFactor.SequenceEqual(new float[] {
+            return (m_entanglementFactor.SequenceEqual(new[] {
                         1F,
                         1F,
                         1F}) == false);


### PR DESCRIPTION
This PR removes unused `using`s, redundant `.ToString()` calls on strings, fixes typos, and simplifies code a bit.