### PR TITLE
Remove unused material from Mesh_PrimitiveVertexColor models

### DIFF
--- a/Output/Mesh_PrimitiveVertexColor/Mesh_PrimitiveVertexColor_00.gltf
+++ b/Output/Mesh_PrimitiveVertexColor/Mesh_PrimitiveVertexColor_00.gltf
@@ -61,9 +61,6 @@
       "name": "Indices"
     }
   ],
-  "materials": [
-    {}
-  ],
   "meshes": [
     {
       "primitives": [
@@ -72,8 +69,7 @@
             "POSITION": 0,
             "COLOR_0": 1
           },
-          "indices": 2,
-          "material": 0
+          "indices": 2
         }
       ]
     }

--- a/Output/Mesh_PrimitiveVertexColor/Mesh_PrimitiveVertexColor_01.gltf
+++ b/Output/Mesh_PrimitiveVertexColor/Mesh_PrimitiveVertexColor_01.gltf
@@ -63,9 +63,6 @@
       "name": "Indices"
     }
   ],
-  "materials": [
-    {}
-  ],
   "meshes": [
     {
       "primitives": [
@@ -74,8 +71,7 @@
             "POSITION": 0,
             "COLOR_0": 1
           },
-          "indices": 2,
-          "material": 0
+          "indices": 2
         }
       ]
     }

--- a/Output/Mesh_PrimitiveVertexColor/Mesh_PrimitiveVertexColor_02.gltf
+++ b/Output/Mesh_PrimitiveVertexColor/Mesh_PrimitiveVertexColor_02.gltf
@@ -63,9 +63,6 @@
       "name": "Indices"
     }
   ],
-  "materials": [
-    {}
-  ],
   "meshes": [
     {
       "primitives": [
@@ -74,8 +71,7 @@
             "POSITION": 0,
             "COLOR_0": 1
           },
-          "indices": 2,
-          "material": 0
+          "indices": 2
         }
       ]
     }

--- a/Output/Mesh_PrimitiveVertexColor/Mesh_PrimitiveVertexColor_03.gltf
+++ b/Output/Mesh_PrimitiveVertexColor/Mesh_PrimitiveVertexColor_03.gltf
@@ -61,9 +61,6 @@
       "name": "Indices"
     }
   ],
-  "materials": [
-    {}
-  ],
   "meshes": [
     {
       "primitives": [
@@ -72,8 +69,7 @@
             "POSITION": 0,
             "COLOR_0": 1
           },
-          "indices": 2,
-          "material": 0
+          "indices": 2
         }
       ]
     }

--- a/Output/Mesh_PrimitiveVertexColor/Mesh_PrimitiveVertexColor_04.gltf
+++ b/Output/Mesh_PrimitiveVertexColor/Mesh_PrimitiveVertexColor_04.gltf
@@ -62,9 +62,6 @@
       "name": "Indices"
     }
   ],
-  "materials": [
-    {}
-  ],
   "meshes": [
     {
       "primitives": [
@@ -73,8 +70,7 @@
             "POSITION": 0,
             "COLOR_0": 1
           },
-          "indices": 2,
-          "material": 0
+          "indices": 2
         }
       ]
     }

--- a/Output/Mesh_PrimitiveVertexColor/Mesh_PrimitiveVertexColor_05.gltf
+++ b/Output/Mesh_PrimitiveVertexColor/Mesh_PrimitiveVertexColor_05.gltf
@@ -62,9 +62,6 @@
       "name": "Indices"
     }
   ],
-  "materials": [
-    {}
-  ],
   "meshes": [
     {
       "primitives": [
@@ -73,8 +70,7 @@
             "POSITION": 0,
             "COLOR_0": 1
           },
-          "indices": 2,
-          "material": 0
+          "indices": 2
         }
       ]
     }

--- a/Source/ModelGroups/Material_MetallicRoughness.cs
+++ b/Source/ModelGroups/Material_MetallicRoughness.cs
@@ -49,12 +49,6 @@ namespace AssetGenerator
                 };
             }
 
-            void SetNoMetallicRoughness(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)
-            {
-                // Uncomment this to fix the empty MetRough material in model 00
-                //meshPrimitive.Material.MetallicRoughnessMaterial = null;
-            }
-
             void SetVertexColor(List<Property> properties, Runtime.MeshPrimitive meshPrimitive)
             {
                 var vertexColors = new[]
@@ -105,7 +99,7 @@ namespace AssetGenerator
             Models = new List<Model>
             {
                 CreateModel((properties, meshPrimitive, metallicRoughness) => {
-                    SetNoMetallicRoughness(properties, meshPrimitive);
+                    // There are no properties set on this model.
                 }),
                 CreateModel((properties, meshPrimitive, metallicRoughness) => {
                     SetVertexColor(properties, meshPrimitive);

--- a/Source/ModelGroups/Mesh_PrimitiveVertexColor.cs
+++ b/Source/ModelGroups/Mesh_PrimitiveVertexColor.cs
@@ -24,7 +24,6 @@ namespace AssetGenerator
             {
                 var properties = new List<Property>();
                 Runtime.MeshPrimitive meshPrimitive = MeshPrimitive.CreateSinglePlane(includeTextureCoords: false);
-                meshPrimitive.Material = new Runtime.Material();
 
                 // Apply the common properties to the gltf. 
                 meshPrimitive.Colors = vertexColors;


### PR DESCRIPTION
Removed the material from this model group. No values were being set on it and removing it did not change the screenshots that were being generated.

[Mesh_PrimitiveVertexColor Readme](https://github.com/stevk/glTF-Asset-Generator/blob/emptyprops/Output/Mesh_PrimitiveVertexColor/README.md)

Fixes #406