### PR TITLE
Add method to better handle conflicts when writing files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,6 @@
 + Error message encountered while debugging `Unhandled Exception: System.UnauthorizedAccessException: Access to the path is denied.`
   + A file could not be overwritten. 
   + Check that the file isn't open in another program and that it isn't set to readonly.
-+ Error message encountered while debugging `An unhandled exception of type 'System.IO.IOException' occurred in System.IO.FileSystem.dll: 'The requested operation cannot be performed on a file with a user-mapped section open'`
-    + Encountered when running the debugger again too quickly after having just run it.
-    + Wait a few seconds longer between debugging sessions to allow the OS to release its locks on the files.
 
 ## Additional Resources
 + [Code Style Guide](Documentation/Code_Style_Guide.md)

--- a/Source/FileHelper.cs
+++ b/Source/FileHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 
 namespace AssetGenerator
@@ -60,7 +59,9 @@ namespace AssetGenerator
                 }
             }
 
-            Console.WriteLine($"Unable to write to file.{Environment.NewLine}Verify that the file is not in use by another program and is not readonly.{Environment.NewLine}Press Enter to try again.");
+            Console.WriteLine($"Unable to write to file.");
+            Console.WriteLine("Verify that the file is not in use by another program and is not readonly.");
+            Console.WriteLine("Press Enter to try again.");
             Console.ReadLine();
             LockCheck(writeFile);
         }

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -88,7 +88,6 @@ namespace AssetGenerator
 
                         // Create the .gltf file and writes the model's data to it.
                         string assetFile = Path.Combine(modelGroupFolder, filename);
-                        //glTFLoader.Interface.SaveModel(gltf, assetFile);
                         FileHelper.LockCheck(() => { glTFLoader.Interface.SaveModel(gltf, assetFile); });
 
                         // Create the .bin file and writes the model's data to it.

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -88,11 +88,12 @@ namespace AssetGenerator
 
                         // Create the .gltf file and writes the model's data to it.
                         string assetFile = Path.Combine(modelGroupFolder, filename);
-                        glTFLoader.Interface.SaveModel(gltf, assetFile);
+                        //glTFLoader.Interface.SaveModel(gltf, assetFile);
+                        FileHelper.LockCheck(() => { glTFLoader.Interface.SaveModel(gltf, assetFile); });
 
                         // Create the .bin file and writes the model's data to it.
                         string dataFile = Path.Combine(modelGroupFolder, data.Name);
-                        File.WriteAllBytes(dataFile, data.ToArray());
+                        FileHelper.LockCheck(() => { File.WriteAllBytes(dataFile, data.ToArray()); });
                     }
 
                     readme.SetupTable(modelGroup, comboIndex, model.Properties);
@@ -105,14 +106,14 @@ namespace AssetGenerator
                 // Write out the manifest JSON specific to this model group.
                 using (var writeModelGroupManifest = new StreamWriter(Path.Combine(modelGroupFolder, "Manifest.json")))
                 {
-                    jsonSerializer.Serialize(writeModelGroupManifest, manifest);
+                    FileHelper.LockCheck(() => { jsonSerializer.Serialize(writeModelGroupManifest, manifest); });
                 }
             }
 
             // Write out the master manifest JSON containing all of the model groups
             using (var writeManifest = new StreamWriter(Path.Combine(outputFolder, "Manifest.json")))
             {
-                jsonSerializer.Serialize(writeManifest, manifestMaster.ToArray());
+                FileHelper.LockCheck(() => { jsonSerializer.Serialize(writeManifest, manifestMaster.ToArray()); });
             }
 
             // Update the main readme.

--- a/Source/ReadmeBuilder.cs
+++ b/Source/ReadmeBuilder.cs
@@ -42,7 +42,7 @@ namespace AssetGenerator
 
             // Write out the readme file.
             string readmeFilePath = Path.Combine(Directory.GetParent(outputFolder).ToString(), "README.md");
-            File.WriteAllText(readmeFilePath, template);
+            FileHelper.LockCheck(() => { File.WriteAllText(readmeFilePath, template);  });
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace AssetGenerator
 
             // Writes the logs out to file.
             string readmeFilePath = Path.Combine(assetFolder, "README.md");
-            File.WriteAllText(readmeFilePath, template);
+            FileHelper.LockCheck(() => { File.WriteAllText(readmeFilePath, template); });
         }
     }
 }

--- a/Source/ReadmeBuilder.cs
+++ b/Source/ReadmeBuilder.cs
@@ -42,7 +42,7 @@ namespace AssetGenerator
 
             // Write out the readme file.
             string readmeFilePath = Path.Combine(Directory.GetParent(outputFolder).ToString(), "README.md");
-            FileHelper.LockCheck(() => { File.WriteAllText(readmeFilePath, template);  });
+            FileHelper.LockCheck(() => { File.WriteAllText(readmeFilePath, template); });
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace AssetGenerator
 
             // Now start the table for generated models.
             // First line of table must be blank.
-            readme.Add(new List<string>()); 
+            readme.Add(new List<string>());
 
             // First cell is empty.
             var firstLine = new List<string>


### PR DESCRIPTION
Previously the app could crash when attempting to write a file if the file was already in use or otherwise locked. Now it retries a few times with a delay, and then halts the app and messages the user to address the issue.

Fixes #481 