### PR TITLE
Add script for generating screenshots and remove powershell dependancy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,6 +29,12 @@
             "type": "node",
             "request": "launch",
             "program": "${workspaceFolder}/Tools/validate.js",
+        },
+        {
+            "name": "Generate Screenshots",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceFolder}/Tools/generateScreenshots.js",
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,12 +19,6 @@
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach",
-            "processId": "${command:pickProcess}"
-        },
-        {
             "name": "Validate Models",
             "type": "node",
             "request": "launch",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 ## Dependencies
 1. Install [Visual Studio Code.](https://code.visualstudio.com/Download) (VS Code)
-2. Install the extension [C# for VS Code (powered by OmniSharp)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
-3. Install [npm.](https://www.npmjs.com/get-npm)
+2. Install the VS Code extension [C# for VS Code (powered by OmniSharp)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+3. Install [npm](https://www.npmjs.com/get-npm)
 
 ## Set Up
 1. Download the repro.

--- a/Documentation/Adding_Models.md
+++ b/Documentation/Adding_Models.md
@@ -99,17 +99,17 @@ At the bottom of the model group `GenerateUsedPropertiesList()` is called. This 
 + Other models are either individual properties being set, or combinations of interest (ones that are likely to interact and cause issues).
 
 ## Generate Screenshots
-1. Download the [screenshotGenerator](https://github.com/kcoley/screenshotGenerator)
+1. Download the [ScreenshotGenerator](https://github.com/kcoley/screenshotGenerator)
     + Follow the directions in that repro's readme on how to build the generator.
     + Place the folder containing the Screenshot Generator inside of the local glTF-Asset-Generator directory `.\glTF-Asset-Generator\ScreenshotGenerator\`
-2. Run the PowerShell script [SampleImageHelper.ps1](../SampleImageHelper.ps1)
+2. Run the `Validate Models` VS Code launch configuration, or run the script directly from the [Tools](../Tools) folder with the command `npm run generateScreenshots`
 
 Screenshots are generated in a step separately from running the glTF Asset Generator, which also includes the moving of textures and figures into the output folders.  
 This is done to speed up debugging. The creation of screenshots is a time intensive process and often the screenshots are not needed until the majority of debugging has been completed.
 
 ## Validate Models
 Run the `Validate Models` VS Code launch configuration in order to use the [glTF-Validator](https://github.com/KhronosGroup/glTF-Validator) to validate the generated models. The results are saved under in the  [ValidatorResults folder](../ValidatorResults).  
-This script can also be run directly from the [Tools](../Tools) folder with the command `npm run validate`.
+This script can also be run directly from the [Tools](../Tools) folder with the command `npm run validate`.  
 New and modified models are expected to have been validated before being checked in.
 
 ## Properties

--- a/Tools/generateScreenshots.js
+++ b/Tools/generateScreenshots.js
@@ -1,0 +1,169 @@
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const exec = require('child_process').exec;
+
+// Declare all of the common paths that will be used in generating screenshots.
+const projectDirectory = path.join(__dirname, '..');
+const outputFolder = path.join(projectDirectory, 'Output');
+const manifestPath = path.join(outputFolder, 'Manifest.json');
+const resourcesDirectory = path.join(projectDirectory, "Source", "Resources");
+const preGenImagesDirectory = path.join(resourcesDirectory, "Figures", "SampleImages");
+const rootTempDirectory = path.join(projectDirectory, "tempImages");
+const tempOutputDirectory = path.join(rootTempDirectory, "Figures");
+const tempSampleImagesDirectory = path.join(tempOutputDirectory, "SampleImages");
+const tempThumbnailsDirectory = path.join(tempOutputDirectory, "Thumbnails");
+const defaultImage = path.join(resourcesDirectory, "Figures", "NYI.png");
+const screenshotGeneratorRoot = path.join(projectDirectory, "ScreenshotGenerator");
+const screenshotGeneratorDirectory = path.join(screenshotGeneratorRoot, 'app');
+const resizeScript = path.join(screenshotGeneratorRoot, "pythonScripts", "dist", "resizeImages.exe");
+
+// Load the manifest into memory.
+var manifest;
+fs.readFile(manifestPath, function(error, data) {
+    if (error) throw error;
+    manifest = JSON.parse(data);
+ });
+ 
+// Create some temp folders. The screenshots will be stored here after generation until being sorted into the Output folder.
+try {
+    fs.mkdirSync(tempOutputDirectory, { recursive: true } );
+    fs.mkdirSync(tempSampleImagesDirectory, { recursive: true } );
+    fs.mkdirSync(tempThumbnailsDirectory, { recursive: true } );
+} catch (e) {
+    console.log('Cannot create folder ', e);
+}
+
+// Generate the screenshots via the ScreenshotGenerator.
+const callScreenshotGenerator = `npm start -- "headless=true" "manifest=${manifestPath}" "outputDirectory=${tempSampleImagesDirectory}"`;
+const callThumbnailGenerator = `${resizeScript} --dir=${tempSampleImagesDirectory} --outputDir=${tempThumbnailsDirectory} --width=72 --height=72`;
+console.log();
+console.log('Running the ScreenshotGenerator...');
+runProgram(callScreenshotGenerator, screenshotGeneratorDirectory, function() {
+    console.log('Finished generating screenshots.');
+    console.log('');
+    console.log('Creating thumbnails...');
+    runProgram(callThumbnailGenerator, screenshotGeneratorDirectory, function() {
+        console.log('Finished generating thumbnails.');
+        console.log('');
+        sortImages()
+        .then(
+            // Delete the temp images directory.
+            console.log('Finished copying images to the Output directory.'),
+            console.log(''),
+            console.log('Cleaning up temporary files...'),
+            deleteFolderRecursive(rootTempDirectory),
+            console.log('Clean up complete.'),
+        );
+    });
+});
+
+function sortImages() {
+    return new Promise(resolve => {
+        // Check for images that are pre-generated.
+        const preGenImages = fs.readdirSync(preGenImagesDirectory);
+        const genImages = fs.readdirSync(tempSampleImagesDirectory);
+        const existingImageList = [];
+
+        for (const genImage in genImages) {
+            for (const preGenImage in preGenImages) {
+                if (genImages[genImage] == preGenImages[preGenImage]) {
+                    existingImageList.push(preGenImages[preGenImage]);
+                    break;
+                }
+            }
+        }
+        if (existingImageList.length > 0) {
+            console.log('The following generated image(s) will not be used, due to there already being a pre-generated image:');
+            for (const image in existingImageList) {
+                console.log(image);
+            }
+        }
+
+        // Move the sample images and thumbnails into their respective folders.
+        console.log('Copying images to the Output directory...');
+        for (const modelgroup in manifest) {
+            const modelGroupPath = path.join(outputFolder, manifest[modelgroup].folder);
+            for (const model in manifest[modelgroup].models) {
+                if (manifest[modelgroup].models[model].sampleImageName != null) {
+                    const thumbnailName = manifest[modelgroup].models[model].sampleImageName.replace('SampleImages', 'Thumbnails');
+
+                    // Builds paths to the expected generated images and their destinations.
+                    const imageDestination = path.join(modelGroupPath, manifest[modelgroup].models[model].sampleImageName);
+                    const imageThumbnailDestination = path.join(modelGroupPath, thumbnailName);
+                    const imageSource = path.join(rootTempDirectory, manifest[modelgroup].models[model].sampleImageName);
+                    const imageThumbnailSource = path.join(rootTempDirectory, thumbnailName);
+
+                    // Create the directory if it doesn't exist.
+                    try {
+                        fs.mkdirSync(path.dirname(imageDestination), { recursive: true } );
+                        fs.mkdirSync(path.dirname(imageThumbnailDestination), { recursive: true } );
+                    } catch (e) {
+                        console.log('Cannot create folder ', e);
+                    }
+
+                    // Check if there is an pre-gen image, and use that filepath instead if it does.
+                    if (existingImageList.Count > 0) {
+                        for (const preGenImage in existingImageList) {
+                            if (existingImageList[preGenImage] == path.basename(manifest[modelgroup].models[model].sampleImageName)) {
+                                imageSource = path.join(resourcesDirectory, manifest[modelgroup].models[model].sampleImageName);
+                                imageThumbnailSource = path.join(resourcesDirectory, thumbnailName);
+                                break;
+                            }
+                        }
+                    }
+
+                    if (fs.existsSync(imageSource) && fs.existsSync(imageThumbnailSource)) {
+                        // Copy the image and thumbnail into the relevant folder in the Output directory.
+                        fs.copyFile(imageSource, imageDestination, (error) => { if (error) throw error; });
+                        fs.copyFile(imageThumbnailSource, imageThumbnailDestination, (error) => { if (error) throw error; });
+                    }
+                    else {
+                        // There is no image, so use a copy of the default image instead.
+                        fs.copyFile(defaultImage, imageDestination, (error) => { if (error) throw error; });
+                        fs.copyFile(defaultImage, imageThumbnailDestination, (error) => { if (error) throw error; });
+                    }
+                    
+                }
+            }
+        }
+        resolve();
+    });
+}
+
+/**
+ * Launches an specified external program.
+ * @param cmd Program to run, including command line parameters.
+ * @param directory Filepath to execute the program from.
+ * @param exitFunc Code to be run on completion. (Exit message, next function, etc...)
+ */
+function runProgram(cmd, directory, exitFunc) {
+    const child = exec(cmd, {cwd: directory, stdio: 'inherit'});
+    child.stdout.on('data', function(data) {
+        console.log(data.toString());
+    });
+    child.stderr.on('data', function(data) {
+        console.log(data.toString());
+    });
+    child.on('close', function() {
+        exitFunc();
+    });
+}
+
+function deleteFolderRecursive(folderPath) {
+    var files = [];
+    if (fs.existsSync(folderPath)) {
+        files = fs.readdirSync(folderPath);
+        files.forEach(function(file,index) {
+            var curPath = path.join(folderPath, file);
+            // Recursive
+            if (fs.lstatSync(curPath).isDirectory()) {
+                deleteFolderRecursive(curPath);
+            } else { 
+                // Delete file
+                fs.unlinkSync(curPath);
+            }
+        });
+        fs.rmdirSync(folderPath);
+    }
+};

--- a/Tools/generateScreenshots.js
+++ b/Tools/generateScreenshots.js
@@ -6,54 +6,47 @@ const exec = require('child_process').exec;
 const projectDirectory = path.join(__dirname, '..');
 const outputFolder = path.join(projectDirectory, 'Output');
 const manifestPath = path.join(outputFolder, 'Manifest.json');
-const resourcesDirectory = path.join(projectDirectory, "Source", "Resources");
-const preGenImagesDirectory = path.join(resourcesDirectory, "Figures", "SampleImages");
-const rootTempDirectory = path.join(projectDirectory, "tempImages");
-const tempOutputDirectory = path.join(rootTempDirectory, "Figures");
-const tempSampleImagesDirectory = path.join(tempOutputDirectory, "SampleImages");
-const tempThumbnailsDirectory = path.join(tempOutputDirectory, "Thumbnails");
-const defaultImage = path.join(resourcesDirectory, "Figures", "NYI.png");
-const screenshotGeneratorRoot = path.join(projectDirectory, "ScreenshotGenerator");
+const resourcesDirectory = path.join(projectDirectory, 'Source', 'Resources');
+const preGenImagesDirectory = path.join(resourcesDirectory, 'Figures', 'SampleImages');
+const rootTempDirectory = path.join(projectDirectory, 'tempImages');
+const tempOutputDirectory = path.join(rootTempDirectory, 'Figures');
+const tempSampleImagesDirectory = path.join(tempOutputDirectory, 'SampleImages');
+const tempThumbnailsDirectory = path.join(tempOutputDirectory, 'Thumbnails');
+const defaultImage = path.join(resourcesDirectory, 'Figures', 'NYI.png');
+const screenshotGeneratorRoot = path.join(projectDirectory, 'ScreenshotGenerator');
 const screenshotGeneratorDirectory = path.join(screenshotGeneratorRoot, 'app');
-const resizeScript = path.join(screenshotGeneratorRoot, "pythonScripts", "dist", "resizeImages.exe");
+const resizeScript = path.join(screenshotGeneratorRoot, 'pythonScripts', 'dist', 'resizeImages.exe');
  
 // Create some temp folders. The screenshots will be stored here after generation until being sorted into the Output folder.
 try {
     fs.mkdirSync(tempOutputDirectory, { recursive: true } );
     fs.mkdirSync(tempSampleImagesDirectory, { recursive: true } );
     fs.mkdirSync(tempThumbnailsDirectory, { recursive: true } );
-} catch (e) {
-    console.log('Cannot create folder ', e);
+} catch (error) {
+    console.log('Cannot create folder');
+    throw error;
 }
 
-// Load the manifest into memory.
-var manifest;
-fs.readFile(manifestPath, function(error, data) {
-    if (error) throw error;
-    manifest = JSON.parse(data);
- });
-
-// Generate the screenshots via the ScreenshotGenerator.
-const callScreenshotGenerator = `npm start -- "headless=true" "manifest=${manifestPath}" "outputDirectory=${tempSampleImagesDirectory}"`;
-const callThumbnailGenerator = `${resizeScript} --dir=${tempSampleImagesDirectory} --outputDir=${tempThumbnailsDirectory} --width=72 --height=72`;
-console.log();
+// Generate the screenshots via the ScreenshotGenerator, resize those screenshots to create thumbnails, 
+// sorts images into the Output directory, and deletes the temporary images folder created by the screenshot generator.
+console.log('');
 console.log('Running the ScreenshotGenerator...');
-runProgram(callScreenshotGenerator, screenshotGeneratorDirectory, function() {
+const screenshotGeneratorCmd = `npm start -- headless=true manifest="${manifestPath}" outputDirectory="${tempSampleImagesDirectory}"`;
+runProgram(screenshotGeneratorCmd, screenshotGeneratorDirectory, function() {
     console.log('Finished generating screenshots.');
     console.log('');
     console.log('Creating thumbnails...');
-    runProgram(callThumbnailGenerator, screenshotGeneratorDirectory, function() {
+    const thumbnailGeneratorCmd = `"${resizeScript}" --dir="${tempSampleImagesDirectory}" --outputDir="${tempThumbnailsDirectory}" --width=72 --height=72`;
+    runProgram(thumbnailGeneratorCmd, screenshotGeneratorDirectory, function() {
         console.log('Finished generating thumbnails.');
         console.log('');
         console.log('Copying images to the Output directory...');
-        sortImages()
-        .then(
-            console.log('Finished copying images to the Output directory.'),
-            console.log(''),
-            console.log('Cleaning up temporary files...'),
-            deleteFolderRecursive(rootTempDirectory),
-            console.log('Clean up complete.'),
-        );
+        sortImages();
+        console.log('Finished copying images to the Output directory.');
+        console.log('');
+        console.log('Cleaning up temporary files...');
+        deleteFolderRecursive(rootTempDirectory);
+        console.log('Clean up complete.');
     });
 });
 
@@ -61,74 +54,71 @@ runProgram(callScreenshotGenerator, screenshotGeneratorDirectory, function() {
  * Moves screenshots and thumbnails from the temp folders into their final location in the Output directory.
  */
 function sortImages() {
-    return new Promise(resolve => {
-        // Check for images that are pre-generated.
-        const preGenImages = fs.readdirSync(preGenImagesDirectory);
-        const genImages = fs.readdirSync(tempSampleImagesDirectory);
-        const existingImageList = [];
+    // Check for images that are pre-generated.
+    const preGenImages = fs.readdirSync(preGenImagesDirectory);
+    const genImages = fs.readdirSync(tempSampleImagesDirectory);
+    const existingImageList = [];
 
-        genImages.forEach(function (genImage) {
-            preGenImages.some(function (preGenImage) {
-                if (genImage == preGenImage) {
-                    existingImageList.push(preGenImage);
-                    return true;
-                } else return false;
-            })
-        });
-        if (existingImageList.length > 0) {
-            console.log('The following generated image(s) will not be used, due to there already being a pre-generated image:');
-            for (const image in existingImageList) {
-                console.log(image);
-            }
+    genImages.forEach(function (genImage) {
+        preGenImages.some(function (preGenImage) {
+            if (genImage == preGenImage) {
+                existingImageList.push(preGenImage);
+                return true;
+            } else return false;
+        })
+    });
+    if (existingImageList.length > 0) {
+        console.log('The following generated image(s) will not be used, due to there already being a pre-generated image:');
+        for (const image in existingImageList) {
+            console.log(image);
         }
+    }
 
-        // Move the sample images and thumbnails into their respective folders.
-        manifest.forEach(function (modelgroup) {
-            const modelGroupPath = path.join(outputFolder, modelgroup.folder);
-            modelgroup.models.forEach(function (model) {
-                if (model.sampleImageName != null) {
-                    const thumbnailName = model.sampleImageName.replace('SampleImages', 'Thumbnails');
+    // Move the sample images and thumbnails into their respective folders.
+    JSON.parse(fs.readFileSync(manifestPath)).forEach(function (modelgroup) {
+        const modelGroupPath = path.join(outputFolder, modelgroup.folder);
+        modelgroup.models.forEach(function (model) {
+            if (model.sampleImageName != null) {
+                const thumbnailName = model.sampleImageName.replace('SampleImages', 'Thumbnails');
 
-                    // Builds paths to the expected generated images and their destinations.
-                    const imageDestination = path.join(modelGroupPath, model.sampleImageName);
-                    const imageThumbnailDestination = path.join(modelGroupPath, thumbnailName);
-                    const imageSource = path.join(rootTempDirectory, model.sampleImageName);
-                    const imageThumbnailSource = path.join(rootTempDirectory, thumbnailName);
+                // Builds paths to the expected generated images and their destinations.
+                const imageDestination = path.join(modelGroupPath, model.sampleImageName);
+                const imageThumbnailDestination = path.join(modelGroupPath, thumbnailName);
+                const imageSource = path.join(rootTempDirectory, model.sampleImageName);
+                const imageThumbnailSource = path.join(rootTempDirectory, thumbnailName);
 
-                    // Create the directory if it doesn't exist.
-                    try {
-                        fs.mkdirSync(path.dirname(imageDestination), { recursive: true } );
-                        fs.mkdirSync(path.dirname(imageThumbnailDestination), { recursive: true } );
-                    } catch (e) {
-                        console.log('Cannot create folder ', e);
-                    }
+                // Create the directory if it doesn't exist.
+                try {
+                    fs.mkdirSync(path.dirname(imageDestination), { recursive: true } );
+                    fs.mkdirSync(path.dirname(imageThumbnailDestination), { recursive: true } );
+                } catch (error) {
+                    console.log('Cannot create folder');
+                    throw error;
+                }
 
-                    // Check if there is an pre-gen image, and use that filepath instead if it does.
-                    if (existingImageList.Count > 0) {
-                        for (const preGenImage in existingImageList) {
-                            if (existingImageList[preGenImage] == path.basename(model.sampleImageName)) {
-                                imageSource = path.join(resourcesDirectory, model.sampleImageName);
-                                imageThumbnailSource = path.join(resourcesDirectory, thumbnailName);
-                                break;
-                            }
+                // Check if there is an pre-gen image, and use that filepath instead if it does.
+                if (existingImageList.Count > 0) {
+                    for (const preGenImage in existingImageList) {
+                        if (existingImageList[preGenImage] == path.basename(model.sampleImageName)) {
+                            imageSource = path.join(resourcesDirectory, model.sampleImageName);
+                            imageThumbnailSource = path.join(resourcesDirectory, thumbnailName);
+                            break;
                         }
                     }
-
-                    if (fs.existsSync(imageSource) && fs.existsSync(imageThumbnailSource)) {
-                        // Copy the image and thumbnail into the relevant folder in the Output directory.
-                        fs.copyFile(imageSource, imageDestination, (error) => { if (error) throw error; });
-                        fs.copyFile(imageThumbnailSource, imageThumbnailDestination, (error) => { if (error) throw error; });
-                    }
-                    else {
-                        // There is no image, so use a copy of the default image instead.
-                        fs.copyFile(defaultImage, imageDestination, (error) => { if (error) throw error; });
-                        fs.copyFile(defaultImage, imageThumbnailDestination, (error) => { if (error) throw error; });
-                    }
-                    
                 }
-            })
-        });
-        resolve();
+
+                if (fs.existsSync(imageSource) && fs.existsSync(imageThumbnailSource)) {
+                    // Copy the image and thumbnail into the relevant folder in the Output directory.
+                    fs.copyFileSync(imageSource, imageDestination, (error) => { if (error) throw error; });
+                    fs.copyFileSync(imageThumbnailSource, imageThumbnailDestination, (error) => { if (error) throw error; });
+                }
+                else {
+                    // There is no image, so use a copy of the default image instead.
+                    fs.copyFileSync(defaultImage, imageDestination, (error) => { if (error) throw error; });
+                    fs.copyFileSync(defaultImage, imageThumbnailDestination, (error) => { if (error) throw error; });
+                }
+            }
+        })
     });
 }
 
@@ -139,7 +129,7 @@ function sortImages() {
  * @param exitFunc Code to be run on completion. (Exit message, next function, etc...)
  */
 function runProgram(cmd, directory, exitFunc) {
-    const child = exec(cmd, {cwd: directory, stdio: 'inherit'});
+    const child = exec(cmd, {cwd: directory});
     child.stdout.on('data', function(data) {
         console.log(data.toString());
     });

--- a/Tools/generateScreenshots.js
+++ b/Tools/generateScreenshots.js
@@ -18,14 +18,9 @@ const screenshotGeneratorDirectory = path.join(screenshotGeneratorRoot, 'app');
 const resizeScript = path.join(screenshotGeneratorRoot, 'pythonScripts', 'dist', 'resizeImages.exe');
  
 // Create some temp folders. The screenshots will be stored here after generation until being sorted into the Output folder.
-try {
-    fs.mkdirSync(tempOutputDirectory, { recursive: true } );
-    fs.mkdirSync(tempSampleImagesDirectory, { recursive: true } );
-    fs.mkdirSync(tempThumbnailsDirectory, { recursive: true } );
-} catch (error) {
-    console.log('Cannot create folder');
-    throw error;
-}
+fs.mkdirSync(tempOutputDirectory, { recursive: true } );
+fs.mkdirSync(tempSampleImagesDirectory, { recursive: true } );
+fs.mkdirSync(tempThumbnailsDirectory, { recursive: true } );
 
 // Generate the screenshots via the ScreenshotGenerator, resize those screenshots to create thumbnails, 
 // sorts images into the Output directory, and deletes the temporary images folder created by the screenshot generator.
@@ -59,14 +54,14 @@ function sortImages() {
     const genImages = fs.readdirSync(tempSampleImagesDirectory);
     const existingImageList = [];
 
-    genImages.forEach(function (genImage) {
-        preGenImages.some(function (preGenImage) {
+    for (const genImage of genImages) {
+        for (const preGenImage of preGenImages) {
             if (genImage == preGenImage) {
                 existingImageList.push(preGenImage);
-                return true;
-            } else return false;
-        })
-    });
+                break;
+            }
+        };
+    };
     if (existingImageList.length > 0) {
         console.log('The following generated image(s) will not be used, due to there already being a pre-generated image:');
         for (const image in existingImageList) {
@@ -88,18 +83,13 @@ function sortImages() {
                 const imageThumbnailSource = path.join(rootTempDirectory, thumbnailName);
 
                 // Create the directory if it doesn't exist.
-                try {
-                    fs.mkdirSync(path.dirname(imageDestination), { recursive: true } );
-                    fs.mkdirSync(path.dirname(imageThumbnailDestination), { recursive: true } );
-                } catch (error) {
-                    console.log('Cannot create folder');
-                    throw error;
-                }
+                fs.mkdirSync(path.dirname(imageDestination), { recursive: true } );
+                fs.mkdirSync(path.dirname(imageThumbnailDestination), { recursive: true } );
 
                 // Check if there is an pre-gen image, and use that filepath instead if it does.
                 if (existingImageList.Count > 0) {
-                    for (const preGenImage in existingImageList) {
-                        if (existingImageList[preGenImage] == path.basename(model.sampleImageName)) {
+                    for (const preGenImage of existingImageList) {
+                        if (preGenImage == path.basename(model.sampleImageName)) {
                             imageSource = path.join(resourcesDirectory, model.sampleImageName);
                             imageThumbnailSource = path.join(resourcesDirectory, thumbnailName);
                             break;

--- a/Tools/package.json
+++ b/Tools/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "validate": "node validate.js"
+    "validate": "node validate.js",
+    "generateScreenshots": "node generateScreenshots.js"
   },
   "dependencies": {
     "gltf-validator": "^2.0.0-dev.2.7"

--- a/Tools/validate.js
+++ b/Tools/validate.js
@@ -82,12 +82,7 @@ function validateModel(glTFAsset) {
         delete report.validatedAt;
 
         // Write the results to file.
-        try {
-            fs.mkdirSync(glTFAsset.logDirectory, { recursive: true } );
-        } catch (e) {
-            console.log('Cannot create folder');
-            throw error;
-        }
+        fs.mkdirSync(glTFAsset.logDirectory, { recursive: true } );
         fs.writeFile(glTFAsset.logFilepath, (JSON.stringify(report, null, 4).replace(/(?:\n)/g, os.EOL)), (error) => {
             if (error) throw error;
         });

--- a/Tools/validate.js
+++ b/Tools/validate.js
@@ -21,7 +21,7 @@ for (const glTFAsset of glTFAssets) {
 
 // Validate each model async. When all models are finished being validated, output the results.
 Promise.all(promises).then(() => {
-    console.log();
+    console.log('');
     console.log('Models verified: ' + glTFAssets.length);
     console.log('Models with errors: ' + assetsWithErrors.length);
 
@@ -49,8 +49,8 @@ Promise.all(promises).then(() => {
     }
 
     // Write the summary report to file.
-    fs.writeFile(path.join(logOutputFolder, 'README.md'), summary.join(os.EOL), (err) => {
-        if (err) throw err;
+    fs.writeFile(path.join(logOutputFolder, 'README.md'), summary.join(os.EOL), (error) => {
+        if (error) throw error;
     });
 });
 
@@ -66,10 +66,10 @@ function validateModel(glTFAsset) {
         externalResourceFunction: (uri) =>
             new Promise((resolve, reject) => {
                 uri = path.resolve(path.dirname(glTFAsset.modelFilepath), decodeURIComponent(uri));
-                fs.readFile(uri, (err, data) => {
-                    if (err) {
-                        console.error(err.toString());
-                        reject(err.toString());
+                fs.readFile(uri, (error, data) => {
+                    if (error) {
+                        console.error(error.toString());
+                        reject(error.toString());
                         return;
                     }
                     resolve(data);
@@ -85,10 +85,11 @@ function validateModel(glTFAsset) {
         try {
             fs.mkdirSync(glTFAsset.logDirectory, { recursive: true } );
         } catch (e) {
-            console.log('Cannot create folder ', e);
+            console.log('Cannot create folder');
+            throw error;
         }
-        fs.writeFile(glTFAsset.logFilepath, (JSON.stringify(report, null, 4).replace(/(?:\n)/g, os.EOL)), (err) => {
-            if (err) throw err;
+        fs.writeFile(glTFAsset.logFilepath, (JSON.stringify(report, null, 4).replace(/(?:\n)/g, os.EOL)), (error) => {
+            if (error) throw error;
         });
 
         // Write a simple result to console as models are completed.


### PR DESCRIPTION
Screenshots are now generated by using the `Generate Screenshots` launch configuration, or by using `npm run generateScreenshots` from the tools directory. This removes our dependency on powershell.

Note that the GenerateScreenshots repro is still external to the project and still needs to be setup separately, the same as before.

Fixes #487