### PR TITLE
Fix framework ver in launch.json and similar cleanup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,16 +2,15 @@
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
+    "version": "0.6.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
+            "name": "Generate Models",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Source/bin/Debug/netcoreapp2.0/AssetGenerator.dll",
-            "args": [],
+            "program": "${workspaceFolder}/Source/bin/Debug/netcoreapp2.2/AssetGenerator.dll",
             "cwd": "${workspaceFolder}/Source",
             // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
             "console": "internalConsole",


### PR DESCRIPTION
Updates the .NET Core version in the launch.json (missed in my previous pull request).

I also updated the version number, change the name of the default launch config to be more explicit, and removed an unused `args` parameter. 