### PR TITLE
Undo instancing of skins with skinB

### DIFF
--- a/Output/Positive/Animation_Skin/Animation_Skin_07.gltf
+++ b/Output/Positive/Animation_Skin/Animation_Skin_07.gltf
@@ -286,7 +286,7 @@
       "name": "joint1"
     },
     {
-      "skin": 0,
+      "skin": 1,
       "mesh": 1,
       "name": "outerPrism"
     }
@@ -302,6 +302,13 @@
     }
   ],
   "skins": [
+    {
+      "inverseBindMatrices": 4,
+      "joints": [
+        1,
+        2
+      ]
+    },
     {
       "inverseBindMatrices": 4,
       "joints": [

--- a/Source/ModelGroup_SkinB.cs
+++ b/Source/ModelGroup_SkinB.cs
@@ -49,7 +49,12 @@ namespace AssetGenerator
                     invertedJoint0,
                     invertedJoint1
                 };
-                var skin = new Runtime.Skin
+                var innerSkin = new Runtime.Skin
+                {
+                    Joints = jointsList,
+                    InverseBindMatrices = inverseBindMatricesList
+                };
+                var outerSkin = new Runtime.Skin
                 {
                     Joints = jointsList,
                     InverseBindMatrices = inverseBindMatricesList
@@ -58,14 +63,14 @@ namespace AssetGenerator
                 var nodeInnerPrism = new Runtime.Node
                 {
                     Name = "innerPrism",
-                    Skin = skin,
+                    Skin = innerSkin,
                     Mesh = Mesh.CreatePrism(colorInner),
                 };
 
                 var nodeOuterPrism = new Runtime.Node
                 {
                     Name = "outerPrism",
-                    Skin = skin,
+                    Skin = outerSkin,
                     Mesh = Mesh.CreatePrism(colorOuter, Scale: new Vector3(1.6f, 1.6f, 0.3f)),
                 };
 


### PR DESCRIPTION
Undo instancing of skins when using skinB. It is confusing to only see one skin listed in a model explicitly testing multiple skins that reference the same joint. This model is not intended to test instancing.

Fixes #543

@donmccurdy Let us know if this change doesn't go far enough. The underlying data of each skin is still the same.