### PR TITLE
Update validator

### DIFF
--- a/Output/Negative/Mesh_NoPosition/ValidatorResults/Mesh_NoPosition_00.json
+++ b/Output/Negative/Mesh_NoPosition/ValidatorResults/Mesh_NoPosition_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_NoPosition_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 1,
@@ -29,13 +29,17 @@
                 "byteLength": 36
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 3,
+        "totalTriangleCount": 1,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_NoPosition/ValidatorResults/Mesh_NoPosition_01.json
+++ b/Output/Negative/Mesh_NoPosition/ValidatorResults/Mesh_NoPosition_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_NoPosition_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 1,
@@ -29,13 +29,17 @@
                 "byteLength": 48
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 3,
+        "totalTriangleCount": 1,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_00.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -12,7 +12,7 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (255) at index 2.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -29,13 +29,17 @@
                 "byteLength": 6139
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 511,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_01.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -12,7 +12,7 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (65535) at index 2.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -29,13 +29,17 @@
                 "byteLength": 1572866
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 131071,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_02.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 2,
         "numWarnings": 0,
@@ -12,13 +12,13 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (255) at index 3.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             },
             {
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (255) at index 4.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -35,13 +35,17 @@
                 "byteLength": 6146
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 511,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_03.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 2,
         "numWarnings": 0,
@@ -12,13 +12,13 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (65535) at index 3.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             },
             {
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (65535) at index 4.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -35,13 +35,17 @@
                 "byteLength": 1572876
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 131071,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_04.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -12,7 +12,7 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (255) at index 2.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -29,13 +29,17 @@
                 "byteLength": 6139
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 511,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_05.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -12,7 +12,7 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (65535) at index 2.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -29,13 +29,17 @@
                 "byteLength": 1572866
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 131071,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_06.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -12,7 +12,7 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (255) at index 2.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -29,13 +29,17 @@
                 "byteLength": 6140
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 511,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_07.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_07.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_07.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -12,7 +12,7 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (65535) at index 2.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -29,13 +29,17 @@
                 "byteLength": 1572868
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 131071,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_08.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_08.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_08.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -12,7 +12,7 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (255) at index 2.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -29,13 +29,17 @@
                 "byteLength": 6139
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 511,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_09.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_09.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_09.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -12,7 +12,7 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (65535) at index 2.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -29,13 +29,17 @@
                 "byteLength": 1572866
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 131071,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_10.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_10.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_10.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -12,7 +12,7 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (255) at index 2.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -29,13 +29,17 @@
                 "byteLength": 6139
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 511,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_11.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_11.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_11.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -12,7 +12,7 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (65535) at index 2.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -29,13 +29,17 @@
                 "byteLength": 1572866
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 131071,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_12.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_12.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_12.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -12,7 +12,7 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (255) at index 2.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -29,13 +29,17 @@
                 "byteLength": 6139
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 511,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_13.json
+++ b/Output/Negative/Mesh_PrimitiveRestart/ValidatorResults/Mesh_PrimitiveRestart_13.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveRestart_13.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -12,7 +12,7 @@
                 "code": "ACCESSOR_INDEX_PRIMITIVE_RESTART",
                 "message": "Indices accessor contains primitive restart value (65535) at index 2.",
                 "severity": 0,
-                "pointer": "/accessors/1"
+                "pointer": "/meshes/0/primitives/0/indices"
             }
         ],
         "truncated": false
@@ -29,13 +29,17 @@
                 "byteLength": 1572866
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 131071,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Animation_Node/ValidatorResults/Animation_Node_00.json
+++ b/Output/Positive/Animation_Node/ValidatorResults/Animation_Node_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Node_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Node/ValidatorResults/Animation_Node_01.json
+++ b/Output/Positive/Animation_Node/ValidatorResults/Animation_Node_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Node_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Node/ValidatorResults/Animation_Node_02.json
+++ b/Output/Positive/Animation_Node/ValidatorResults/Animation_Node_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Node_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Node/ValidatorResults/Animation_Node_03.json
+++ b/Output/Positive/Animation_Node/ValidatorResults/Animation_Node_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Node_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Node/ValidatorResults/Animation_Node_04.json
+++ b/Output/Positive/Animation_Node/ValidatorResults/Animation_Node_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Node_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Node/ValidatorResults/Animation_Node_05.json
+++ b/Output/Positive/Animation_Node/ValidatorResults/Animation_Node_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Node_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_00.json
+++ b/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_NodeMisc_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_01.json
+++ b/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_NodeMisc_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_02.json
+++ b/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_NodeMisc_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_03.json
+++ b/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_NodeMisc_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_04.json
+++ b/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_NodeMisc_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 3
+        "drawCallCount": 2,
+        "totalVertexCount": 48,
+        "totalTriangleCount": 24,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_05.json
+++ b/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_NodeMisc_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_06.json
+++ b/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_NodeMisc_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_07.json
+++ b/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_07.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_NodeMisc_07.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 2,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_08.json
+++ b/Output/Positive/Animation_NodeMisc/ValidatorResults/Animation_NodeMisc_08.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_NodeMisc_08.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_SamplerType/ValidatorResults/Animation_SamplerType_00.json
+++ b/Output/Positive/Animation_SamplerType/ValidatorResults/Animation_SamplerType_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_SamplerType_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_SamplerType/ValidatorResults/Animation_SamplerType_01.json
+++ b/Output/Positive/Animation_SamplerType/ValidatorResults/Animation_SamplerType_01.json
@@ -1,32 +1,13 @@
 {
     "uri": "Animation_SamplerType_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
-        "numErrors": 3,
+        "numErrors": 0,
         "numWarnings": 0,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [
-            {
-                "code": "ACCESSOR_NON_UNIT",
-                "message": "Accessor element at index 3 is not of unit length: 1.0021985875084924.",
-                "severity": 0,
-                "pointer": "/accessors/5"
-            },
-            {
-                "code": "ACCESSOR_NON_UNIT",
-                "message": "Accessor element at index 11 is not of unit length: 1.0021985875084924.",
-                "severity": 0,
-                "pointer": "/accessors/5"
-            },
-            {
-                "code": "ACCESSOR_NON_UNIT",
-                "message": "Accessor element at index 19 is not of unit length: 1.0021985875084924.",
-                "severity": 0,
-                "pointer": "/accessors/5"
-            }
-        ],
+        "messages": [],
         "truncated": false
     },
     "info": {
@@ -48,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_SamplerType/ValidatorResults/Animation_SamplerType_02.json
+++ b/Output/Positive/Animation_SamplerType/ValidatorResults/Animation_SamplerType_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_SamplerType_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 24,
+        "totalTriangleCount": 12,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_00.json
+++ b/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Skin_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 392
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 4,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_01.json
+++ b/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Skin_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 452
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 4,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_02.json
+++ b/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_02.json
@@ -1,13 +1,26 @@
 {
     "uri": "Animation_Skin_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 2,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "NODE_SKINNED_MESH_NON_ROOT",
+                "message": "Node with a skinned mesh is not root. Parent transforms will not affect a skinned mesh.",
+                "severity": 1,
+                "pointer": "/nodes/1"
+            },
+            {
+                "code": "NODE_SKINNED_MESH_LOCAL_TRANSFORMS",
+                "message": "Local transforms will not affect a skinned mesh.",
+                "severity": 1,
+                "pointer": "/nodes/1"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -22,13 +35,17 @@
                 "byteLength": 392
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 4,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_03.json
+++ b/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Skin_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 264
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 4,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_04.json
+++ b/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Skin_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 500
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 3
+        "drawCallCount": 2,
+        "totalVertexCount": 9,
+        "totalTriangleCount": 5,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_05.json
+++ b/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Skin_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 464
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 3
+        "drawCallCount": 2,
+        "totalVertexCount": 12,
+        "totalTriangleCount": 8,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_06.json
+++ b/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_06.json
@@ -1,13 +1,20 @@
 {
     "uri": "Animation_Skin_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
-        "numErrors": 0,
+        "numErrors": 1,
         "numWarnings": 0,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "SKIN_NO_COMMON_ROOT",
+                "message": "Joints do not have a common root.",
+                "severity": 0,
+                "pointer": "/skins/0/joints"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -22,13 +29,17 @@
                 "byteLength": 392
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 4,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_07.json
+++ b/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_07.json
@@ -1,13 +1,50 @@
 {
     "uri": "Animation_Skin_07.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 6,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 1 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 1 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/1/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 5 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 5 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/1/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 9 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 9 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/1/primitives/0/attributes/JOINTS_0"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -22,13 +59,17 @@
                 "byteLength": 764
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 3
+        "drawCallCount": 2,
+        "totalVertexCount": 12,
+        "totalTriangleCount": 12,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_08.json
+++ b/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_08.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Skin_08.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 776
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 10,
+        "totalTriangleCount": 8,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_09.json
+++ b/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_09.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Skin_09.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 1036
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 3
+        "drawCallCount": 2,
+        "totalVertexCount": 15,
+        "totalTriangleCount": 11,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_10.json
+++ b/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_10.json
@@ -1,13 +1,182 @@
 {
     "uri": "Animation_Skin_10.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 28,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 1 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 2 (component index 2) is used with zero weight but has non-zero value (2).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 3 (component index 3) is used with zero weight but has non-zero value (3).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 5 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 6 (component index 2) is used with zero weight but has non-zero value (2).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 7 (component index 3) is used with zero weight but has non-zero value (3).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 10 (component index 2) is used with zero weight but has non-zero value (2).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 11 (component index 3) is used with zero weight but has non-zero value (3).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 14 (component index 2) is used with zero weight but has non-zero value (2).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 15 (component index 3) is used with zero weight but has non-zero value (3).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 18 (component index 2) is used with zero weight but has non-zero value (2).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 19 (component index 3) is used with zero weight but has non-zero value (3).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 21 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 23 (component index 3) is used with zero weight but has non-zero value (3).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 25 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 27 (component index 3) is used with zero weight but has non-zero value (3).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 29 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 31 (component index 3) is used with zero weight but has non-zero value (3).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 33 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 35 (component index 3) is used with zero weight but has non-zero value (3).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 37 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 38 (component index 2) is used with zero weight but has non-zero value (2).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 41 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 42 (component index 2) is used with zero weight but has non-zero value (2).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 45 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 46 (component index 2) is used with zero weight but has non-zero value (2).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 49 (component index 1) is used with zero weight but has non-zero value (1).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            },
+            {
+                "code": "ACCESSOR_JOINTS_USED_ZERO_WEIGHT",
+                "message": "Joints accessor element at index 50 (component index 2) is used with zero weight but has non-zero value (2).",
+                "severity": 1,
+                "pointer": "/meshes/0/primitives/0/attributes/JOINTS_0"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -22,13 +191,17 @@
                 "byteLength": 844
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 13,
+        "totalTriangleCount": 10,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_11.json
+++ b/Output/Positive/Animation_Skin/ValidatorResults/Animation_Skin_11.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_Skin_11.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 520
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 4,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_SkinType/ValidatorResults/Animation_SkinType_00.json
+++ b/Output/Positive/Animation_SkinType/ValidatorResults/Animation_SkinType_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_SkinType_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 428
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 4,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_SkinType/ValidatorResults/Animation_SkinType_01.json
+++ b/Output/Positive/Animation_SkinType/ValidatorResults/Animation_SkinType_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_SkinType_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 356
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 4,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_SkinType/ValidatorResults/Animation_SkinType_02.json
+++ b/Output/Positive/Animation_SkinType/ValidatorResults/Animation_SkinType_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_SkinType_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 380
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 4,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Animation_SkinType/ValidatorResults/Animation_SkinType_03.json
+++ b/Output/Positive/Animation_SkinType/ValidatorResults/Animation_SkinType_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Animation_SkinType_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 452
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 4,
+        "maxUVs": 0,
+        "maxInfluences": 4,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Buffer_Interleaved/ValidatorResults/Buffer_Interleaved_00.json
+++ b/Output/Positive/Buffer_Interleaved/ValidatorResults/Buffer_Interleaved_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Buffer_Interleaved_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 256,
                     "height": 256,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Buffer_Interleaved/ValidatorResults/Buffer_Interleaved_01.json
+++ b/Output/Positive/Buffer_Interleaved/ValidatorResults/Buffer_Interleaved_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Buffer_Interleaved_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 256,
                     "height": 256,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Buffer_Interleaved/ValidatorResults/Buffer_Interleaved_02.json
+++ b/Output/Positive/Buffer_Interleaved/ValidatorResults/Buffer_Interleaved_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Buffer_Interleaved_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 256,
                     "height": 256,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Buffer_Interleaved/ValidatorResults/Buffer_Interleaved_03.json
+++ b/Output/Positive/Buffer_Interleaved/ValidatorResults/Buffer_Interleaved_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Buffer_Interleaved_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 256,
                     "height": 256,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Buffer_Interleaved/ValidatorResults/Buffer_Interleaved_04.json
+++ b/Output/Positive/Buffer_Interleaved/ValidatorResults/Buffer_Interleaved_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Buffer_Interleaved_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 256,
                     "height": 256,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Buffer_Misc/ValidatorResults/Buffer_Misc_00.json
+++ b/Output/Positive/Buffer_Misc/ValidatorResults/Buffer_Misc_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Buffer_Misc_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,13 +29,17 @@
                 "byteLength": 48
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": false,
+        "animationCount": 1,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Compatibility/ValidatorResults/Compatibility_00.json
+++ b/Output/Positive/Compatibility/ValidatorResults/Compatibility_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Compatibility_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Compatibility/ValidatorResults/Compatibility_01.json
+++ b/Output/Positive/Compatibility/ValidatorResults/Compatibility_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Compatibility_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 2,
@@ -18,7 +18,7 @@
                 "code": "UNKNOWN_ASSET_MINOR_VERSION",
                 "message": "Unknown glTF minor asset version: 1.",
                 "severity": 1,
-                "pointer": "/asset"
+                "pointer": "/asset/version"
             }
         ],
         "truncated": false
@@ -35,13 +35,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Compatibility/ValidatorResults/Compatibility_02.json
+++ b/Output/Positive/Compatibility/ValidatorResults/Compatibility_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Compatibility_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 2,
@@ -12,7 +12,7 @@
                 "code": "UNKNOWN_ASSET_MINOR_VERSION",
                 "message": "Unknown glTF minor asset version: 1.",
                 "severity": 1,
-                "pointer": "/asset"
+                "pointer": "/asset/version"
             },
             {
                 "code": "UNEXPECTED_PROPERTY",
@@ -35,13 +35,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Compatibility/ValidatorResults/Compatibility_03.json
+++ b/Output/Positive/Compatibility/ValidatorResults/Compatibility_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Compatibility_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 2,
@@ -12,7 +12,7 @@
                 "code": "UNKNOWN_ASSET_MINOR_VERSION",
                 "message": "Unknown glTF minor asset version: 1.",
                 "severity": 1,
-                "pointer": "/asset"
+                "pointer": "/asset/version"
             },
             {
                 "code": "UNEXPECTED_PROPERTY",
@@ -41,13 +41,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Compatibility/ValidatorResults/Compatibility_04.json
+++ b/Output/Positive/Compatibility/ValidatorResults/Compatibility_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Compatibility_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 1,
@@ -12,7 +12,7 @@
                 "code": "UNKNOWN_ASSET_MINOR_VERSION",
                 "message": "Unknown glTF minor asset version: 1.",
                 "severity": 1,
-                "pointer": "/asset"
+                "pointer": "/asset/version"
             }
         ],
         "truncated": false
@@ -30,13 +30,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Compatibility/ValidatorResults/Compatibility_05.json
+++ b/Output/Positive/Compatibility/ValidatorResults/Compatibility_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Compatibility_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 2,
@@ -47,13 +47,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Compatibility/ValidatorResults/Compatibility_06.json
+++ b/Output/Positive/Compatibility/ValidatorResults/Compatibility_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Compatibility_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -25,13 +25,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_00.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_00.json
@@ -1,13 +1,20 @@
 {
     "uri": "Instancing_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 1,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/0"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -29,18 +36,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 8,
+        "totalTriangleCount": 4,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_01.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_01.json
@@ -1,13 +1,26 @@
 {
     "uri": "Instancing_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 2,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/0"
+            },
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/1"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -29,7 +42,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             },
@@ -41,18 +56,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 8,
+        "totalTriangleCount": 4,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_02.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_02.json
@@ -1,13 +1,20 @@
 {
     "uri": "Instancing_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 1,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/0"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -29,18 +36,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 8,
+        "totalTriangleCount": 4,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_03.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_03.json
@@ -1,13 +1,20 @@
 {
     "uri": "Instancing_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 1,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/0"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -29,18 +36,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 8,
+        "totalTriangleCount": 4,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_04.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_04.json
@@ -1,13 +1,26 @@
 {
     "uri": "Instancing_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 2,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/0"
+            },
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/1"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -29,7 +42,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             },
@@ -41,18 +56,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 8,
+        "totalTriangleCount": 4,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_05.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_05.json
@@ -1,13 +1,26 @@
 {
     "uri": "Instancing_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 2,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/0"
+            },
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/1"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -29,7 +42,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             },
@@ -41,18 +56,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 8,
+        "totalTriangleCount": 4,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_06.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_06.json
@@ -1,13 +1,20 @@
 {
     "uri": "Instancing_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 1,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/0"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -29,18 +36,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_07.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_07.json
@@ -1,13 +1,20 @@
 {
     "uri": "Instancing_07.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 1,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/0"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -29,18 +36,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_08.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_08.json
@@ -1,13 +1,26 @@
 {
     "uri": "Instancing_08.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 2,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/0"
+            },
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/1"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -29,7 +42,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             },
@@ -41,18 +56,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 4
+        "drawCallCount": 2,
+        "totalVertexCount": 12,
+        "totalTriangleCount": 8,
+        "maxUVs": 1,
+        "maxInfluences": 4,
+        "maxAttributes": 4
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_09.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_09.json
@@ -1,13 +1,26 @@
 {
     "uri": "Instancing_09.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 2,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/0"
+            },
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/1"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -29,7 +42,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             },
@@ -41,18 +56,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 4
+        "drawCallCount": 2,
+        "totalVertexCount": 12,
+        "totalTriangleCount": 8,
+        "maxUVs": 1,
+        "maxInfluences": 4,
+        "maxAttributes": 4
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_10.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_10.json
@@ -1,13 +1,26 @@
 {
     "uri": "Instancing_10.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
-        "numWarnings": 0,
+        "numWarnings": 2,
         "numInfos": 0,
         "numHints": 0,
-        "messages": [],
+        "messages": [
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/0"
+            },
+            {
+                "code": "IMAGE_FEATURES_UNSUPPORTED",
+                "message": "Image contains unsupported features like non-default colorspace information, non-square pixels, or animation.",
+                "severity": 1,
+                "pointer": "/images/1"
+            }
+        ],
         "truncated": false
     },
     "info": {
@@ -29,7 +42,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             },
@@ -41,18 +56,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "custom",
+                    "transfer": "custom",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": true,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 4
+        "drawCallCount": 2,
+        "totalVertexCount": 12,
+        "totalTriangleCount": 8,
+        "maxUVs": 1,
+        "maxInfluences": 4,
+        "maxAttributes": 4
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_11.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_11.json
@@ -1,7 +1,7 @@
 {
     "uri": "Instancing_11.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 3
+        "drawCallCount": 2,
+        "totalVertexCount": 48,
+        "totalTriangleCount": 24,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_12.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_12.json
@@ -1,7 +1,7 @@
 {
     "uri": "Instancing_12.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 3
+        "drawCallCount": 2,
+        "totalVertexCount": 48,
+        "totalTriangleCount": 24,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Instancing/ValidatorResults/Instancing_13.json
+++ b/Output/Positive/Instancing/ValidatorResults/Instancing_13.json
@@ -1,7 +1,7 @@
 {
     "uri": "Instancing_13.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": true,
-        "hasMaterials": true,
+        "animationCount": 1,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 3
+        "drawCallCount": 2,
+        "totalVertexCount": 48,
+        "totalTriangleCount": 24,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Material/ValidatorResults/Material_00.json
+++ b/Output/Positive/Material/ValidatorResults/Material_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Material/ValidatorResults/Material_01.json
+++ b/Output/Positive/Material/ValidatorResults/Material_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Material/ValidatorResults/Material_02.json
+++ b/Output/Positive/Material/ValidatorResults/Material_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "LUMINANCE",
+                    "format": "luminance",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material/ValidatorResults/Material_03.json
+++ b/Output/Positive/Material/ValidatorResults/Material_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Material/ValidatorResults/Material_04.json
+++ b/Output/Positive/Material/ValidatorResults/Material_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Material/ValidatorResults/Material_05.json
+++ b/Output/Positive/Material/ValidatorResults/Material_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "LUMINANCE",
+                    "format": "luminance",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material/ValidatorResults/Material_06.json
+++ b/Output/Positive/Material/ValidatorResults/Material_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material/ValidatorResults/Material_07.json
+++ b/Output/Positive/Material/ValidatorResults/Material_07.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_07.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "LUMINANCE",
+                    "format": "luminance",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_00.json
+++ b/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaBlend_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 136
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_01.json
+++ b/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaBlend_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_02.json
+++ b/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaBlend_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_03.json
+++ b/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaBlend_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_04.json
+++ b/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaBlend_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 136
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_05.json
+++ b/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaBlend_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_06.json
+++ b/Output/Positive/Material_AlphaBlend/ValidatorResults/Material_AlphaBlend_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaBlend_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_00.json
+++ b/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaMask_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_01.json
+++ b/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaMask_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_02.json
+++ b/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaMask_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_03.json
+++ b/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaMask_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_04.json
+++ b/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaMask_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_05.json
+++ b/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaMask_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_06.json
+++ b/Output/Positive/Material_AlphaMask/ValidatorResults/Material_AlphaMask_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_AlphaMask_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_DoubleSided/ValidatorResults/Material_DoubleSided_00.json
+++ b/Output/Positive/Material_DoubleSided/ValidatorResults/Material_DoubleSided_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_DoubleSided_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_DoubleSided/ValidatorResults/Material_DoubleSided_01.json
+++ b/Output/Positive/Material_DoubleSided/ValidatorResults/Material_DoubleSided_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_DoubleSided_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Material_DoubleSided/ValidatorResults/Material_DoubleSided_02.json
+++ b/Output/Positive/Material_DoubleSided/ValidatorResults/Material_DoubleSided_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_DoubleSided_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,18 +43,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Material_DoubleSided/ValidatorResults/Material_DoubleSided_03.json
+++ b/Output/Positive/Material_DoubleSided/ValidatorResults/Material_DoubleSided_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_DoubleSided_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,18 +43,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 4
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 4
     }
 }

--- a/Output/Positive/Material_DoubleSided/ValidatorResults/Material_DoubleSided_04.json
+++ b/Output/Positive/Material_DoubleSided/ValidatorResults/Material_DoubleSided_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_DoubleSided_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,18 +43,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_00.json
+++ b/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_MetallicRoughness_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_01.json
+++ b/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_MetallicRoughness_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 120
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_02.json
+++ b/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_MetallicRoughness_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_03.json
+++ b/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_MetallicRoughness_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_04.json
+++ b/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_MetallicRoughness_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_05.json
+++ b/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_MetallicRoughness_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_06.json
+++ b/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_MetallicRoughness_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_07.json
+++ b/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_07.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_MetallicRoughness_07.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_08.json
+++ b/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_08.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_MetallicRoughness_08.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_09.json
+++ b/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_09.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_MetallicRoughness_09.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_10.json
+++ b/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_10.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_MetallicRoughness_10.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_11.json
+++ b/Output/Positive/Material_MetallicRoughness/ValidatorResults/Material_MetallicRoughness_11.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_MetallicRoughness_11.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,18 +43,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Material_Mixed/ValidatorResults/Material_Mixed_00.json
+++ b/Output/Positive/Material_Mixed/ValidatorResults/Material_Mixed_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_Mixed_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -32,18 +32,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_Mixed/ValidatorResults/Material_Mixed_01.json
+++ b/Output/Positive/Material_Mixed/ValidatorResults/Material_Mixed_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_Mixed_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -32,18 +32,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_Mixed/ValidatorResults/Material_Mixed_02.json
+++ b/Output/Positive/Material_Mixed/ValidatorResults/Material_Mixed_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_Mixed_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -32,18 +32,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_00.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,18 +35,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_01.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,18 +35,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_02.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,7 +35,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -47,18 +49,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_03.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,18 +35,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_04.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,7 +35,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -47,18 +49,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_05.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,18 +35,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_06.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,18 +35,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_07.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_07.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_07.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,7 +35,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -47,18 +49,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_08.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_08.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_08.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,7 +35,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -47,18 +49,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_09.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_09.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_09.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,7 +35,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -47,18 +49,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_10.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_10.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_10.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,7 +35,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -47,18 +49,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_11.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_11.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_11.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,7 +35,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -47,18 +49,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_12.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_12.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_12.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,7 +35,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -47,18 +49,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_13.json
+++ b/Output/Positive/Material_SpecularGlossiness/ValidatorResults/Material_SpecularGlossiness_13.json
@@ -1,7 +1,7 @@
 {
     "uri": "Material_SpecularGlossiness_13.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -35,7 +35,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -47,7 +49,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -59,18 +63,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_00.json
+++ b/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveAttribute_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_01.json
+++ b/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveAttribute_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_02.json
+++ b/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveAttribute_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_03.json
+++ b/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveAttribute_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_04.json
+++ b/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveAttribute_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,18 +43,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_05.json
+++ b/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveAttribute_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,18 +43,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 3
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_06.json
+++ b/Output/Positive/Mesh_PrimitiveAttribute/ValidatorResults/Mesh_PrimitiveAttribute_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveAttribute_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,18 +43,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 4
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 4
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_00.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 12288
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 1024,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_01.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 96
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 8,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_02.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 48
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_03.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 60
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 5,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_04.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 48
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_05.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 48
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_06.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_07.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_07.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_07.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 16384
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 1024,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_08.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_08.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_08.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 80
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_09.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_09.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_09.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 64
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_10.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_10.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_10.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 68
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_11.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_11.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_11.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 64
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_12.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_12.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_12.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 64
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_13.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_13.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_13.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 72
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_14.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_14.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_14.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 54
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_15.json
+++ b/Output/Positive/Mesh_PrimitiveMode/ValidatorResults/Mesh_PrimitiveMode_15.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveMode_15.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 60
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 1
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitiveVertexColor/ValidatorResults/Mesh_PrimitiveVertexColor_00.json
+++ b/Output/Positive/Mesh_PrimitiveVertexColor/ValidatorResults/Mesh_PrimitiveVertexColor_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveVertexColor_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 120
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Mesh_PrimitiveVertexColor/ValidatorResults/Mesh_PrimitiveVertexColor_01.json
+++ b/Output/Positive/Mesh_PrimitiveVertexColor/ValidatorResults/Mesh_PrimitiveVertexColor_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveVertexColor_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 88
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Mesh_PrimitiveVertexColor/ValidatorResults/Mesh_PrimitiveVertexColor_02.json
+++ b/Output/Positive/Mesh_PrimitiveVertexColor/ValidatorResults/Mesh_PrimitiveVertexColor_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveVertexColor_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 104
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Mesh_PrimitiveVertexColor/ValidatorResults/Mesh_PrimitiveVertexColor_03.json
+++ b/Output/Positive/Mesh_PrimitiveVertexColor/ValidatorResults/Mesh_PrimitiveVertexColor_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveVertexColor_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 136
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Mesh_PrimitiveVertexColor/ValidatorResults/Mesh_PrimitiveVertexColor_04.json
+++ b/Output/Positive/Mesh_PrimitiveVertexColor/ValidatorResults/Mesh_PrimitiveVertexColor_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveVertexColor_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 88
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Mesh_PrimitiveVertexColor/ValidatorResults/Mesh_PrimitiveVertexColor_05.json
+++ b/Output/Positive/Mesh_PrimitiveVertexColor/ValidatorResults/Mesh_PrimitiveVertexColor_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitiveVertexColor_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 104
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Mesh_Primitives/ValidatorResults/Mesh_Primitives_00.json
+++ b/Output/Positive/Mesh_Primitives/ValidatorResults/Mesh_Primitives_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_Primitives_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 96
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_00.json
+++ b/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitivesUV_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -22,13 +22,17 @@
                 "byteLength": 96
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": false,
+        "animationCount": 0,
+        "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": false,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 1
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 1
     }
 }

--- a/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_01.json
+++ b/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitivesUV_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,18 +43,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 5
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 5
     }
 }

--- a/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_02.json
+++ b/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitivesUV_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,18 +43,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 5
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 5
     }
 }

--- a/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_03.json
+++ b/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitivesUV_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,18 +43,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 5
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 5
     }
 }

--- a/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_04.json
+++ b/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitivesUV_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -9,10 +9,10 @@
         "numHints": 0,
         "messages": [
             {
-                "code": "MESH_PRIMITIVE_UNUSED_TEXCOORD",
-                "message": "Material does not use texture coordinates sets with indices (0).",
+                "code": "UNUSED_OBJECT",
+                "message": "This object may be unused.",
                 "severity": 2,
-                "pointer": "/meshes/0/primitives/0/material"
+                "pointer": "/meshes/0/primitives/0/attributes/TEXCOORD_0"
             }
         ],
         "truncated": false
@@ -36,7 +36,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -48,18 +50,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 6
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 2,
+        "maxInfluences": 0,
+        "maxAttributes": 6
     }
 }

--- a/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_05.json
+++ b/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitivesUV_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -9,10 +9,10 @@
         "numHints": 0,
         "messages": [
             {
-                "code": "MESH_PRIMITIVE_UNUSED_TEXCOORD",
-                "message": "Material does not use texture coordinates sets with indices (0).",
+                "code": "UNUSED_OBJECT",
+                "message": "This object may be unused.",
                 "severity": 2,
-                "pointer": "/meshes/0/primitives/1/material"
+                "pointer": "/meshes/0/primitives/1/attributes/TEXCOORD_0"
             }
         ],
         "truncated": false
@@ -36,7 +36,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -48,18 +50,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 6
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 2,
+        "maxInfluences": 0,
+        "maxAttributes": 6
     }
 }

--- a/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_06.json
+++ b/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitivesUV_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -9,10 +9,10 @@
         "numHints": 0,
         "messages": [
             {
-                "code": "MESH_PRIMITIVE_UNUSED_TEXCOORD",
-                "message": "Material does not use texture coordinates sets with indices (0).",
+                "code": "UNUSED_OBJECT",
+                "message": "This object may be unused.",
                 "severity": 2,
-                "pointer": "/meshes/0/primitives/1/material"
+                "pointer": "/meshes/0/primitives/1/attributes/TEXCOORD_0"
             }
         ],
         "truncated": false
@@ -36,7 +36,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -48,18 +50,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 6
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 2,
+        "maxInfluences": 0,
+        "maxAttributes": 6
     }
 }

--- a/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_07.json
+++ b/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_07.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitivesUV_07.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -9,10 +9,10 @@
         "numHints": 0,
         "messages": [
             {
-                "code": "MESH_PRIMITIVE_UNUSED_TEXCOORD",
-                "message": "Material does not use texture coordinates sets with indices (0).",
+                "code": "UNUSED_OBJECT",
+                "message": "This object may be unused.",
                 "severity": 2,
-                "pointer": "/meshes/0/primitives/0/material"
+                "pointer": "/meshes/0/primitives/0/attributes/TEXCOORD_0"
             }
         ],
         "truncated": false
@@ -36,7 +36,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -48,18 +50,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 6
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 2,
+        "maxInfluences": 0,
+        "maxAttributes": 6
     }
 }

--- a/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_08.json
+++ b/Output/Positive/Mesh_PrimitivesUV/ValidatorResults/Mesh_PrimitivesUV_08.json
@@ -1,7 +1,7 @@
 {
     "uri": "Mesh_PrimitivesUV_08.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -9,16 +9,16 @@
         "numHints": 0,
         "messages": [
             {
-                "code": "MESH_PRIMITIVE_UNUSED_TEXCOORD",
-                "message": "Material does not use texture coordinates sets with indices (0).",
+                "code": "UNUSED_OBJECT",
+                "message": "This object may be unused.",
                 "severity": 2,
-                "pointer": "/meshes/0/primitives/0/material"
+                "pointer": "/meshes/0/primitives/0/attributes/TEXCOORD_0"
             },
             {
-                "code": "MESH_PRIMITIVE_UNUSED_TEXCOORD",
-                "message": "Material does not use texture coordinates sets with indices (0).",
+                "code": "UNUSED_OBJECT",
+                "message": "This object may be unused.",
                 "severity": 2,
-                "pointer": "/meshes/0/primitives/1/material"
+                "pointer": "/meshes/0/primitives/1/attributes/TEXCOORD_0"
             }
         ],
         "truncated": false
@@ -42,7 +42,9 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -54,18 +56,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 6
+        "drawCallCount": 2,
+        "totalVertexCount": 6,
+        "totalTriangleCount": 2,
+        "maxUVs": 2,
+        "maxInfluences": 0,
+        "maxAttributes": 6
     }
 }

--- a/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_00.json
+++ b/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_Attribute_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_01.json
+++ b/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_Attribute_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_02.json
+++ b/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_Attribute_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_03.json
+++ b/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_Attribute_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_04.json
+++ b/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_Attribute_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_05.json
+++ b/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_Attribute_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_06.json
+++ b/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_Attribute_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_07.json
+++ b/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_07.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_Attribute_07.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_08.json
+++ b/Output/Positive/Node_Attribute/ValidatorResults/Node_Attribute_08.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_Attribute_08.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_00.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_01.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_02.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_03.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_04.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_05.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_06.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 2
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_07.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_07.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_07.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 3
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_08.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_08.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_08.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 3
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_09.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_09.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_09.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 3
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 3
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_10.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_10.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_10.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 4
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 4
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_11.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_11.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_11.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 4
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 4
     }
 }

--- a/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_12.json
+++ b/Output/Positive/Node_NegativeScale/ValidatorResults/Node_NegativeScale_12.json
@@ -1,7 +1,7 @@
 {
     "uri": "Node_NegativeScale_12.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,7 +29,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -41,7 +43,9 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             },
@@ -53,18 +57,24 @@
                 "image": {
                     "width": 2048,
                     "height": 2048,
-                    "format": "RGB",
+                    "format": "rgb",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 2,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 2,
-        "maxAttributesUsed": 4
+        "drawCallCount": 2,
+        "totalVertexCount": 196,
+        "totalTriangleCount": 54,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 4
     }
 }

--- a/Output/Positive/README.md
+++ b/Output/Positive/README.md
@@ -23,22 +23,22 @@
 | Model | Status | Errors | Warnings | Infos | Hints |
 | :---: | :---: | :---: | :---: | :---: | :---: |
 | [00](Animation_SamplerType/ValidatorResults/Animation_SamplerType_00.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [01](Animation_SamplerType/ValidatorResults/Animation_SamplerType_01.json) | :x: | 3 | 0 | 0 | 0 |
+| [01](Animation_SamplerType/ValidatorResults/Animation_SamplerType_01.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
 | [02](Animation_SamplerType/ValidatorResults/Animation_SamplerType_02.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
 # Animation  Skin
 | Model | Status | Errors | Warnings | Infos | Hints |
 | :---: | :---: | :---: | :---: | :---: | :---: |
 | [00](Animation_Skin/ValidatorResults/Animation_Skin_00.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
 | [01](Animation_Skin/ValidatorResults/Animation_Skin_01.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [02](Animation_Skin/ValidatorResults/Animation_Skin_02.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
+| [02](Animation_Skin/ValidatorResults/Animation_Skin_02.json) | :white_check_mark: | 0 | 2 | 0 | 0 |
 | [03](Animation_Skin/ValidatorResults/Animation_Skin_03.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
 | [04](Animation_Skin/ValidatorResults/Animation_Skin_04.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
 | [05](Animation_Skin/ValidatorResults/Animation_Skin_05.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [06](Animation_Skin/ValidatorResults/Animation_Skin_06.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [07](Animation_Skin/ValidatorResults/Animation_Skin_07.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
+| [06](Animation_Skin/ValidatorResults/Animation_Skin_06.json) | :x: | 1 | 0 | 0 | 0 |
+| [07](Animation_Skin/ValidatorResults/Animation_Skin_07.json) | :white_check_mark: | 0 | 6 | 0 | 0 |
 | [08](Animation_Skin/ValidatorResults/Animation_Skin_08.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
 | [09](Animation_Skin/ValidatorResults/Animation_Skin_09.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [10](Animation_Skin/ValidatorResults/Animation_Skin_10.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
+| [10](Animation_Skin/ValidatorResults/Animation_Skin_10.json) | :white_check_mark: | 0 | 28 | 0 | 0 |
 | [11](Animation_Skin/ValidatorResults/Animation_Skin_11.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
 # Animation  Skin Type
 | Model | Status | Errors | Warnings | Infos | Hints |
@@ -72,17 +72,17 @@
 # Instancing
 | Model | Status | Errors | Warnings | Infos | Hints |
 | :---: | :---: | :---: | :---: | :---: | :---: |
-| [00](Instancing/ValidatorResults/Instancing_00.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [01](Instancing/ValidatorResults/Instancing_01.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [02](Instancing/ValidatorResults/Instancing_02.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [03](Instancing/ValidatorResults/Instancing_03.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [04](Instancing/ValidatorResults/Instancing_04.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [05](Instancing/ValidatorResults/Instancing_05.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [06](Instancing/ValidatorResults/Instancing_06.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [07](Instancing/ValidatorResults/Instancing_07.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [08](Instancing/ValidatorResults/Instancing_08.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [09](Instancing/ValidatorResults/Instancing_09.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
-| [10](Instancing/ValidatorResults/Instancing_10.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
+| [00](Instancing/ValidatorResults/Instancing_00.json) | :white_check_mark: | 0 | 1 | 0 | 0 |
+| [01](Instancing/ValidatorResults/Instancing_01.json) | :white_check_mark: | 0 | 2 | 0 | 0 |
+| [02](Instancing/ValidatorResults/Instancing_02.json) | :white_check_mark: | 0 | 1 | 0 | 0 |
+| [03](Instancing/ValidatorResults/Instancing_03.json) | :white_check_mark: | 0 | 1 | 0 | 0 |
+| [04](Instancing/ValidatorResults/Instancing_04.json) | :white_check_mark: | 0 | 2 | 0 | 0 |
+| [05](Instancing/ValidatorResults/Instancing_05.json) | :white_check_mark: | 0 | 2 | 0 | 0 |
+| [06](Instancing/ValidatorResults/Instancing_06.json) | :white_check_mark: | 0 | 1 | 0 | 0 |
+| [07](Instancing/ValidatorResults/Instancing_07.json) | :white_check_mark: | 0 | 1 | 0 | 0 |
+| [08](Instancing/ValidatorResults/Instancing_08.json) | :white_check_mark: | 0 | 2 | 0 | 0 |
+| [09](Instancing/ValidatorResults/Instancing_09.json) | :white_check_mark: | 0 | 2 | 0 | 0 |
+| [10](Instancing/ValidatorResults/Instancing_10.json) | :white_check_mark: | 0 | 2 | 0 | 0 |
 | [11](Instancing/ValidatorResults/Instancing_11.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
 | [12](Instancing/ValidatorResults/Instancing_12.json) | :white_check_mark: | 0 | 0 | 0 | 0 |
 | [13](Instancing/ValidatorResults/Instancing_13.json) | :white_check_mark: | 0 | 0 | 0 | 0 |

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_00.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_00.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_00.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_01.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_01.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_01.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_02.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_02.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_02.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_03.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_03.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_03.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_04.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_04.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_04.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_05.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_05.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_05.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_06.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_06.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_06.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_07.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_07.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_07.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_08.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_08.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_08.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_09.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_09.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_09.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_10.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_10.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_10.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_11.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_11.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_11.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_12.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_12.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_12.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_13.json
+++ b/Output/Positive/Texture_Sampler/ValidatorResults/Texture_Sampler_13.json
@@ -1,7 +1,7 @@
 {
     "uri": "Texture_Sampler_13.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.2.7",
+    "validatorVersion": "2.0.0-dev.3.2",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,
@@ -29,18 +29,24 @@
                 "image": {
                     "width": 1024,
                     "height": 1024,
-                    "format": "RGBA",
+                    "format": "rgba",
+                    "primaries": "srgb",
+                    "transfer": "srgb",
                     "bits": 8
                 }
             }
         ],
-        "hasAnimations": false,
-        "hasMaterials": true,
+        "animationCount": 0,
+        "materialCount": 1,
         "hasMorphTargets": false,
         "hasSkins": false,
         "hasTextures": true,
         "hasDefaultScene": true,
-        "primitivesCount": 1,
-        "maxAttributesUsed": 2
+        "drawCallCount": 1,
+        "totalVertexCount": 4,
+        "totalTriangleCount": 2,
+        "maxUVs": 1,
+        "maxInfluences": 0,
+        "maxAttributes": 2
     }
 }

--- a/Tools/package-lock.json
+++ b/Tools/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "gltf-validator": {
-      "version": "2.0.0-dev.2.7",
-      "resolved": "https://registry.npmjs.org/gltf-validator/-/gltf-validator-2.0.0-dev.2.7.tgz",
-      "integrity": "sha512-OmI/inmNEL9uDTxj6KNF+/oZ7df2okhi1HKMV7cjakzo2k/MFKpa95R4dMG6WQx1KaiZAG7hvdpSxvjtkTyb2A=="
+      "version": "2.0.0-dev.3.2",
+      "resolved": "https://registry.npmjs.org/gltf-validator/-/gltf-validator-2.0.0-dev.3.2.tgz",
+      "integrity": "sha512-gdG28HR+nDF00b8XkUl/Vxua4Cndc7v1nK4RO3G7JBAm7TiEnCQWETMYRgJR+0BfBt3dWWKsnJXGC+WjaILVmQ=="
     }
   }
 }

--- a/Tools/package.json
+++ b/Tools/package.json
@@ -4,6 +4,6 @@
     "generateScreenshots": "node generateScreenshots.js"
   },
   "dependencies": {
-    "gltf-validator": "^2.0.0-dev.2.7"
+    "gltf-validator": "^2.0.0-dev.3.2"
   }
 }

--- a/Tools/validate.js
+++ b/Tools/validate.js
@@ -93,6 +93,7 @@ async function validateModel(glTFAsset) {
 
     return validator.validateBytes(new Uint8Array(asset), {
         uri: glTFAsset.modelName,
+        writeTimestamp: false,
         externalResourceFunction: (uri) =>
             new Promise((resolve, reject) => {
                 uri = path.resolve(path.dirname(glTFAsset.modelFilepath), decodeURIComponent(uri));
@@ -107,9 +108,6 @@ async function validateModel(glTFAsset) {
             })
     }).then((report) => {
         glTFAsset.report = report;
-
-        // The property 'validatedAt' shows up as a change every time the validator is run. Deleting in order to focus diff results on actual changes.
-        delete report.validatedAt;
 
         // Write the results to file.
         fs.mkdirSync(glTFAsset.logDirectory, { recursive: true } );


### PR DESCRIPTION
This PR updates the validator to the current release.

Note the updated status of sample models:

| Sample | `2.0.0-dev.2.7` | `2.0.0-dev.3.2` | Comment |
|-----------------------------|---------------------|----------------------------------------------------------------------|---------|
| Animation_SamplerType_01 | `ACCESSOR_NON_UNIT` | :white_check_mark: | See 1 |
| Animation_Skin_02 | :white_check_mark: | `NODE_SKINNED_MESH_NON_ROOT`<br>`NODE_SKINNED_MESH_LOCAL_TRANSFORMS` |  |
| Animation_Skin_06 | :white_check_mark: | `SKIN_NO_COMMON_ROOT` |  |
| Animation_Skin_07 | :white_check_mark: | `ACCESSOR_JOINTS_USED_ZERO_WEIGHT` |  |
| Animation_Skin_10 | :white_check_mark: | `ACCESSOR_JOINTS_USED_ZERO_WEIGHT` |  |
| Instancing_00-10 | :white_check_mark: | `IMAGE_FEATURES_UNSUPPORTED` | See 2 |

**Comments**
1. Threshold adjustment.
2. `Textures\BaseColor_A.png` and `Textures\BaseColor_B.png` contain embedded ICC profiles (GIMP default sRGB). Such metadata should be omitted.